### PR TITLE
Add XSD support

### DIFF
--- a/grlc.py
+++ b/grlc.py
@@ -178,11 +178,12 @@ def swagger_spec(user, repo):
             for v, p in parameters.items():
                 param = {}
                 param['name'] = p['name']
-                param['type'] = "string"
+                param['type'] = p['type']
                 param['required'] = p['required']
                 param['in'] = "query"
-                param['enum'] = p['enum']
                 param['description'] = "A value of type {} that will substitute {} in the original query".format(p['type'], p['original'])
+                if p['enum']:
+                    param['enum'] = p['enum']
 
                 params.append(param)
 


### PR DESCRIPTION
Was having issues replacing parameters on a query using Basil syntax. In particular, was having problems with parameters which do not come from an enum.

More specifically, I was getting errors loading and executing [this](https://github.com/c-martinez/grlc-test/blob/master/basilTest.rq) example query, when I was calling it like this:

```
http://localhost:8088/api/c-martinez/grlc-test/basilTest?year=2000
```

This PR solves the issue and adds the `PREFIX xsd` if required.