### PR TITLE
Added process_query_text and extra metadata

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -8,7 +8,7 @@ import logging
 
 glogger = logging.getLogger(__name__)
 
-def build_spec(user, repo, default=False):
+def build_spec(user, repo, default=False, extraMetadata=[]):
     '''
     Build grlc specification for the given github user / repo
     default: guess an API instead of reading it from remote .rq files
@@ -47,109 +47,117 @@ def build_spec(user, repo, default=False):
                 resp = requests.get(raw_query_uri).text
 
                 glogger.info("Processing query " + raw_query_uri)
-                try:
-                    query_metadata = gquery.get_metadata(resp)
-                except Exception as e:
-                    glogger.error("Could not parse query at {}".format(raw_query_uri))
-                    glogger.error(e)
-                    continue
-
-                tags = query_metadata['tags'] if 'tags' in query_metadata else []
-                glogger.debug("Read query tags: " + ', '.join(tags))
-
-                summary = query_metadata['summary'] if 'summary' in query_metadata else ""
-                glogger.debug("Read query summary: " + summary)
-
-                description = query_metadata['description'] if 'description' in query_metadata else ""
-                glogger.debug("Read query description: " + description)
-
-                method = query_metadata['method'].lower() if 'method' in query_metadata else "get"
-                if method not in ['get', 'post', 'head', 'put', 'delete', 'options', 'connect']:
-                    method = "get"
-
-                pagination = query_metadata['pagination'] if 'pagination' in query_metadata else ""
-                glogger.debug("Read query pagination: " + str(pagination))
-
-                # endpoint = query_metadata['endpoint'] if 'endpoint' in query_metadata else ""
-                endpoint = gquery.guess_endpoint_uri("", raw_repo_uri)
-                glogger.debug("Read query endpoint: " + endpoint)
-
-                try:
-                    parameters = gquery.get_parameters(query_metadata['query'], endpoint)
-                except Exception as e:
-                    print traceback.print_exc()
-
-                    glogger.error("Could not parse parameters of query {}".format(raw_query_uri))
-                    continue
-
-                glogger.debug("Read request parameters")
-                glogger.debug(parameters)
-                # TODO: do something intelligent with the parameters!
-                # As per #3, prefetching IRIs via SPARQL and filling enum
-
-                params = []
-                for v, p in parameters.items():
-                    param = {}
-                    param['name'] = p['name']
-                    param['type'] = p['type']
-                    param['required'] = p['required']
-                    param['in'] = "query"
-                    param['description'] = "A value of type {} that will substitute {} in the original query".format(p['type'], p['original'])
-                    if p['enum']:
-                        param['enum'] = p['enum']
-
-                    params.append(param)
-
-                # If this query allows pagination, add page number as parameter
-                if pagination:
-                    pagination_param = {}
-                    pagination_param['name'] = "page"
-                    pagination_param['type'] = "int"
-                    pagination_param['in'] = "query"
-                    pagination_param['description'] = "The page number for this paginated query ({} results per page)".format(pagination)
-                    params.append(pagination_param)
-
-                item_properties = {}
-                if query_metadata['type'] != 'SelectQuery':
-                    # TODO: Turn this into a nicer thingamajim
-                    glogger.warning("This is not a SelectQuery, don't really know what to do!")
-                    summary += "WARNING: non-SELECT queries are not really treated properly yet"
-                    # just continue with empty item_properties
-                else:
-                    # We now know it is a SELECT query
-                    for pv in query_metadata['variables']:
-                        item_properties[pv] = {
-                            "name": pv,
-                            "type": "object",
-                            "required": ["type", "value"],
-                            "properties": {
-                                "type": {
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "type": "string"
-                                },
-                                "xml:lang": {
-                                    "type": "string"
-                                },
-                                "datatype": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                item = {
-                    'call_name': call_name,
-                    'method': method,
-                    'tags': tags,
-                    'summary': summary,
-                    'description': description,
-                    'params': params,
-                    'item_properties': item_properties,
-                    'query': query_metadata['query']
-                }
-                items.append(item)
+                item = process_query_text(resp, raw_query_uri, raw_repo_uri, call_name, extraMetadata)
+                if item:
+                    items.append(item)
 
     return items
+
+def process_query_text(resp, raw_query_uri, raw_repo_uri, call_name, extraMetadata):
+    try:
+        query_metadata = gquery.get_metadata(resp)
+    except Exception as e:
+        glogger.error("Could not parse query at {}".format(raw_query_uri))
+        glogger.error(e)
+        return None
+
+    tags = query_metadata['tags'] if 'tags' in query_metadata else []
+    glogger.debug("Read query tags: " + ', '.join(tags))
+
+    summary = query_metadata['summary'] if 'summary' in query_metadata else ""
+    glogger.debug("Read query summary: " + summary)
+
+    description = query_metadata['description'] if 'description' in query_metadata else ""
+    glogger.debug("Read query description: " + description)
+
+    method = query_metadata['method'].lower() if 'method' in query_metadata else "get"
+    if method not in ['get', 'post', 'head', 'put', 'delete', 'options', 'connect']:
+        method = "get"
+
+    pagination = query_metadata['pagination'] if 'pagination' in query_metadata else ""
+    glogger.debug("Read query pagination: " + str(pagination))
+
+    # endpoint = query_metadata['endpoint'] if 'endpoint' in query_metadata else ""
+    endpoint = gquery.guess_endpoint_uri("", raw_repo_uri)
+    glogger.debug("Read query endpoint: " + endpoint)
+
+    try:
+        parameters = gquery.get_parameters(query_metadata['query'], endpoint)
+    except Exception as e:
+        print traceback.print_exc()
+        glogger.error("Could not parse parameters of query {}".format(raw_query_uri))
+        return None
+
+    glogger.debug("Read request parameters")
+    glogger.debug(parameters)
+    # TODO: do something intelligent with the parameters!
+    # As per #3, prefetching IRIs via SPARQL and filling enum
+
+    params = []
+    for v, p in parameters.items():
+        param = {}
+        param['name'] = p['name']
+        param['type'] = p['type']
+        param['required'] = p['required']
+        param['in'] = "query"
+        param['description'] = "A value of type {} that will substitute {} in the original query".format(p['type'], p['original'])
+        if p['enum']:
+            param['enum'] = p['enum']
+
+        params.append(param)
+
+    # If this query allows pagination, add page number as parameter
+    if pagination:
+        pagination_param = {}
+        pagination_param['name'] = "page"
+        pagination_param['type'] = "int"
+        pagination_param['in'] = "query"
+        pagination_param['description'] = "The page number for this paginated query ({} results per page)".format(pagination)
+        params.append(pagination_param)
+
+    item_properties = {}
+    if query_metadata['type'] != 'SelectQuery':
+        # TODO: Turn this into a nicer thingamajim
+        glogger.warning("This is not a SelectQuery, don't really know what to do!")
+        summary += "WARNING: non-SELECT queries are not really treated properly yet"
+        # just continue with empty item_properties
+    else:
+        # We now know it is a SELECT query
+        for pv in query_metadata['variables']:
+            item_properties[pv] = {
+                "name": pv,
+                "type": "object",
+                "required": ["type", "value"],
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    },
+                    "xml:lang": {
+                        "type": "string"
+                    },
+                    "datatype": {
+                        "type": "string"
+                    }
+                }
+            }
+    item = {
+        'call_name': call_name,
+        'method': method,
+        'tags': tags,
+        'summary': summary,
+        'description': description,
+        'params': params,
+        'item_properties': item_properties,
+        'query': query_metadata['query']
+    }
+    for extraField in extraMetadata:
+        if extraField in query_metadata:
+            item[extraField] = query_metadata[extraField]
+
+    return item
 
 def build_swagger_spec(user, repo, serverName, default=False):
     '''Build GRLC specification for the given github user / repo in swagger format '''


### PR DESCRIPTION
Splitting `build_spec` further, moving some code to new function `process_query_text`. In this way, it is possible to parse the text of a query even if it has not yet been committed to github. This is handy for testing queries before putting them online.

Also, added an `extraMetadata` parameter, which allows to return other metadata which we might be interested on.