### PR TITLE
Add the ability to set custom request headers

### DIFF
--- a/src/gquery.py
+++ b/src/gquery.py
@@ -71,7 +71,7 @@ def count_query_results(query, endpoint):
 
     return 1000
 
-def get_parameters(rq, endpoint):
+def get_parameters(rq, endpoint, headers=None):
     """
         ?_name The variable specifies the API mandatory parameter name. The value is incorporated in the query as plain literal.
         ?__name The parameter name is optional.
@@ -110,9 +110,7 @@ def get_parameters(rq, endpoint):
                 else:
                     codes_subquery = re.sub("SELECT.*\{.*\}.*", "SELECT DISTINCT ?" + v + " WHERE { " + vtpattern + " }", rq, flags=re.DOTALL)
                 glogger.debug("Codes subquery: {}".format(codes_subquery))
-                headers = {
-                    'Accept' : 'application/json'
-                }
+                headers = headers if headers else { 'Accept' : 'application/json' }
                 data = {
                     'query' : codes_subquery
                 }

--- a/src/utils.py
+++ b/src/utils.py
@@ -82,7 +82,8 @@ def process_query_text(resp, raw_query_uri, raw_repo_uri, call_name, extraMetada
     glogger.debug("Read query endpoint: " + endpoint)
 
     try:
-        parameters = gquery.get_parameters(query_metadata['query'], endpoint)
+        headers = query_metadata['headers'] if 'headers' in query_metadata else None
+        parameters = gquery.get_parameters(query_metadata['query'], endpoint, headers=headers)
     except Exception as e:
         print traceback.print_exc()
         glogger.error("Could not parse parameters of query {}".format(raw_query_uri))


### PR DESCRIPTION
This is a bit of a hack, but...

The endpoint I am using won't return proper json unless my headers are `{ 'Accept' : 'application/sparql-results+json' }`

I have added the `headers` metadata field like on my `*.rq` files:

```
#+ headers: { 'Accept' : 'application/sparql-results+json' }
```

and then, if I have `headers` on my metadata, I'm using those headers on my request.

Is this useful? Do other end points require custom headers?

The alternative is to make sure my endpoint support  `{ 'Accept' : 'application/json' }`. 