### PR TITLE
Change 'Accept' header

### DIFF
--- a/src/gquery.py
+++ b/src/gquery.py
@@ -149,7 +149,7 @@ def get_enumeration(rq, v, endpoint):
         else:
             codes_subquery = re.sub("SELECT.*\{.*\}.*", "SELECT DISTINCT ?" + v + " WHERE { " + vtpattern + " }", rq, flags=re.DOTALL)
         glogger.debug("Codes subquery: {}".format(codes_subquery))
-        codes_json = requests.get(endpoint, params={'query' : codes_subquery}, headers={'Accept' : 'application/json'}).json()
+        codes_json = requests.get(endpoint, params={'query' : codes_subquery}, headers={'Accept' : static.mimetypes['json']}).json()
         for code in codes_json['results']['bindings']:
             vcodes.append(code.values()[0]["value"])
 

--- a/src/gquery.py
+++ b/src/gquery.py
@@ -10,7 +10,6 @@ import logging
 import traceback
 import re
 import requests
-import json
 
 # grlc modules
 import static
@@ -94,11 +93,12 @@ def get_parameters(rq, endpoint):
             continue
 
         match = variable_matcher.match(v)
-	# TODO: currently only one parameter per triple pattern is supported
+        # TODO: currently only one parameter per triple pattern is supported
         if match :
             vname = match.group('name')
             # We only fire the enum filling queries if indicated by the query metadata
-            vcodes = get_enumeration(rq, v, endpoint) if vname in get_metadata(rq)['enumerate'] else []
+            metadata = get_metadata(rq)
+            vcodes = get_enumeration(rq, v, endpoint) if 'enumerate' in metadata and vname in metadata['enumerate'] else []
             vrequired = True if match.group('required') == '_' else False
             vtype = 'literal'
             vlang = None

--- a/src/utils.py
+++ b/src/utils.py
@@ -26,7 +26,7 @@ def build_spec(user, repo, default=False, extraMetadata=[]):
         endpoint = gquery.guess_endpoint_uri("", raw_repo_uri)
         glogger.info("Building default API for endpoint {}".format(endpoint))
 
-        types_json = requests.get(endpoint, params={'query': static.SPARQL_TYPES}, headers={'Accept': 'application/json'}).json()
+        types_json = requests.get(endpoint, params={'query': static.SPARQL_TYPES}, headers={'Accept': static.mimetypes['json']}).json()
         for entity_type in types_json['results']['bindings']:
             # Each of these is an entity type in the endpoint
             entity_type_uri = entity_type['type']['value']


### PR DESCRIPTION
As suggested on #42, changed the `Accept` header so it will support `application/json` or `application/sparql-results+json`.

It turns out that `static.mimetypes` already has support for these headers. However, as they are, I think 
`application/json` is given preference over `application/sparql-results+json`. It doesn't make much difference, but if `application/sparql-results+json` is supposed to be the official accept value, then perhaps it should be given preference.
