### PR TITLE
Pip install

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2017 Albert Meroño, VU University Amsterdam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ grlc, the <b>g</b>it <b>r</b>epository <b>l</b>inked data API <b>c</b>onstructor
 ### Install and run
 
 <pre>
-git clone https://github.com/CLARIAH/grlc
-cd grlc
 virtualenv .
 source bin/activate
-pip install -r requirements.txt
-python src/server.py
+pip install git+git://github.com/CLARIAH/grlc
+grlc-server
 </pre>
 
 Direct your browser to [http://localhost:8088](http://localhost:8088).
 
-Alternatively, you can use the provided Gunicorn configuration to run it as a daemon on your server.
+Alternatively, you can use the provided Gunicorn configuration to run it as a daemon on your server. You can use [this gunicorn_config.py](./gunicorn_config.py).
+
+<pre>
+gunicorn -c gunicorn_config.py grlc.server:app
+</pre>
 
 #### Docker
 
@@ -29,7 +31,7 @@ A bundle containing grlc, nginx and other dependencies is available at https://h
 
 - `docker pull clariah/grlc:1.0.0`: install the container
 - `docker-compose up`: launch grlc
-- `docker-compose up /bin/bash`: get into container 
+- `docker-compose up /bin/bash`: get into container
 
 ### Usage
 
@@ -63,7 +65,7 @@ A couple of SPARQL comment embedded decorators are available to make your swagge
     <pre>&#35;+ enumerate:
   &#35;+   - var1
   &#35;+   - var2</pre>
-  
+
   Notice that these should be plain variable names without SPARQL/BASIL conventions (so `var1` instead of `?_var1_iri`)
 
 See examples at [https://github.com/CEDAR-project/Queries](https://github.com/CEDAR-project/Queries).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ grlc, the <b>g</b>it <b>r</b>epository <b>l</b>inked data API <b>c</b>onstructor
 
 **Author:**	Albert Meroño  
 **Copyright:**	Albert Meroño, VU University Amsterdam  
-**License:**	MIT License (see [license.txt](license.txt))
+**License:**	MIT License (see [LICENSE.txt](LICENSE.txt))
 
 ## Install and run
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
+import os
 
 with open('requirements.txt') as f:
     required = f.read().splitlines()
+
+grlc_base = 'src/'
+grlc_data = [ root.replace(grlc_base, '') + '/*' for root,dirs,files in os.walk(grlc_base) ]
 
 setup(name='grlc',
       version='1.0',
@@ -12,6 +16,7 @@ setup(name='grlc',
       url='https://github.com/CLARIAH/grlc',
       packages=['grlc'],
       package_dir = {'grlc': 'src'},
+      package_data = {'grlc': grlc_data},
       scripts=['bin/grlc-server'],
       install_requires=required
      )

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,15 @@ with open('requirements.txt') as f:
 
 grlc_base = 'src/'
 grlc_data = [ root.replace(grlc_base, '') + '/*' for root,dirs,files in os.walk(grlc_base) ]
+grlc_version = '1.0'
 
 setup(name='grlc',
-      version='1.0',
+      version=grlc_version,
       description='grlc, the git repository linked data API constructor',
       author='Albert Meroño',
+      author_email='albert.merono@vu.nl',
       url='https://github.com/CLARIAH/grlc',
-      download_url='https://github.com/c-martinez/grlc/tarball/0.9',
+      download_url='https://github.com/CLARIAH/grlc/tarball/' + grlc_version,
       packages=['grlc'],
       package_dir = {'grlc': 'src'},
       package_data = {'grlc': grlc_data},

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: iso-8859-15 -*-
 
 from distutils.core import setup
 import os
@@ -14,6 +15,7 @@ setup(name='grlc',
       description='grlc, the git repository linked data API constructor',
       author='Albert Meroño',
       url='https://github.com/CLARIAH/grlc',
+      download_url='https://github.com/c-martinez/grlc/tarball/0.9',
       packages=['grlc'],
       package_dir = {'grlc': 'src'},
       package_data = {'grlc': grlc_data},


### PR DESCRIPTION
Before PR is merged, `pip install git+git://github.com/CLARIAH/grlc` will not work.

Instead, test using:
```
pip install git+git://github.com/c-martinez/grlc.git@pipInstall
```

Once this works, we can add grlc to [pypi](https://pypi.python.org/pypi), and we will be able to install by doing `pip install grlc` ;-)