### PR TITLE
Make endpoint configurable

### DIFF
--- a/config.default.ini
+++ b/config.default.ini
@@ -1,2 +1,9 @@
 [auth]
 github_access_token = xxx
+
+[local]
+local_sparql_dir = ./
+
+[defaults]
+# Default endpoint, if none specified elsewhere
+sparql_endpoint = http://dbpedia.org/sparql

--- a/src/gquery.py
+++ b/src/gquery.py
@@ -41,6 +41,7 @@ def guess_endpoint_uri(rq, ru):
         # TODO: except all is really ugly
         except:
             # Default
+            endpoint = static.DEFAULT_ENDPOINT
             glogger.warning("No endpoint specified, using default ({})".format(endpoint))
 
     return endpoint

--- a/src/static.py
+++ b/src/static.py
@@ -24,9 +24,6 @@ mimetypes = {
 # Logging format (prettier than the ugly standard in Flask)
 LOG_FORMAT = '%(asctime)-15s [%(levelname)s] (%(module)s.%(funcName)s) %(message)s'
 
-# Default endpoint, if none specified elsewhere
-DEFAULT_ENDPOINT = 'http://dbpedia.org/sparql'
-
 # GitHub base URLS
 GITHUB_RAW_BASE_URL = 'https://raw.githubusercontent.com/'
 GITHUB_API_BASE_URL = 'https://api.github.com/repos/'
@@ -39,3 +36,6 @@ CACHE_CONTROL_POLICY = 'public, max-age=86400' # 24 hours
 config = SafeConfigParser()
 config.read('config.ini')
 ACCESS_TOKEN = config.get('auth', 'github_access_token')
+
+# Default endpoint, if none specified elsewhere
+DEFAULT_ENDPOINT = config.get('defaults', 'sparql_endpoint')


### PR DESCRIPTION
One option for hiding sparql endpoints is to have `DEFAULT_ENDPOINT`to be configurable via the `config.ini` file.

This may (at least partially) solve issues #76 and #72 .

