### PR TITLE
Serve local queries

### DIFF
--- a/config.default.ini
+++ b/config.default.ini
@@ -5,5 +5,9 @@ github_access_token = xxx
 local_sparql_dir = ./
 
 [defaults]
+<<<<<<< 4deb219ca7039b9076036135ec6a2ed9b0d41eb6
 # Default endpoint, if none specified elsewhere
 sparql_endpoint = http://dbpedia.org/sparql
+=======
+server_name = grlc.io
+>>>>>>> Serve queries from local folder

--- a/src/fileLoaders.py
+++ b/src/fileLoaders.py
@@ -49,7 +49,7 @@ class GithubLoader(BaseLoader):
 
     def getTextFor(self, fileItem):
         raw_query_uri = fileItem['download_url']
-        resp = self._getUriText(raw_query_uri)
+        resp = self._getText(raw_query_uri)
 
         # Add query URI as used entity by the logged activity
         self.prov.add_used_entity(raw_query_uri)

--- a/src/fileLoaders.py
+++ b/src/fileLoaders.py
@@ -1,0 +1,84 @@
+import static as static
+import requests
+
+from glob import glob
+
+from queryTypes import qType
+
+class BaseLoader:
+    def getTextForName(self, query_name):
+        # The URIs of all candidates
+        rq_name = query_name + '.rq'
+        sparql_name = query_name + '.sparql'
+        tpf_name = query_name + '.tpf'
+        candidates = [
+            (rq_name, qType['SPARQL']),
+            (sparql_name, qType['SPARQL']),
+            (tpf_name, qType['TPF'])
+        ]
+
+        for queryFullName, queryType in candidates:
+            queryText = self._getText(queryFullName)
+            if queryText:
+                return queryText, queryType
+        # No query found...
+        return '', None
+
+class GithubLoader(BaseLoader):
+    def __init__(self, user, repo, sha, prov):
+        self.user = user
+        self.repo = repo
+        self.sha = sha
+        self.prov = prov
+
+    def fetchFiles(self):
+        api_repo_content_uri = static.GITHUB_API_BASE_URL + self.user + '/' + self.repo + '/contents'
+        params = {
+            'ref' : 'master' if self.sha is None else self.sha
+        }
+        resp = requests.get(api_repo_content_uri, headers={'Authorization': 'token {}'.format(static.ACCESS_TOKEN)}, params=params).json()
+        return resp
+
+    def getRawRepoUri(self):
+        raw_repo_uri = static.GITHUB_RAW_BASE_URL + self.user + '/' + self.repo
+        if self.sha is None:
+            raw_repo_uri += '/master/'
+        else:
+            raw_repo_uri += '/blob/{}/'.format(self.sha)
+        return raw_repo_uri
+
+    def getTextFor(self, fileItem):
+        raw_query_uri = fileItem['download_url']
+        resp = self._getUriText(raw_query_uri)
+
+        # Add query URI as used entity by the logged activity
+        self.prov.add_used_entity(raw_query_uri)
+        return resp
+
+    def _getText(self, query_name):
+        query_uri = self.getRawRepoUri() + query_name
+        req = requests.get(query_uri, headers={'Authorization': 'token {}'.format(static.ACCESS_TOKEN)})
+        if req.status_code == 200:
+            return req.text
+        else:
+            return None
+
+class LocalLoader(BaseLoader):
+    def __init__(self):
+        self.baseDir = static.LOCAL_SPARQL_DIR
+
+    def fetchFiles(self):
+        files = glob(self.baseDir + '*')
+        return [ { 'name': f.replace(self.baseDir, '') } for f in files ]
+
+    def getRawRepoUri(self):
+        return ''
+
+    def _getText(self, query_name):
+        f = open(self.baseDir + query_name, 'r')
+        lines = f.readlines()
+        text = ''.join(lines)
+        return text
+
+    def getTextFor(self, fileItem):
+        return self._getText(fileItem['name'])

--- a/src/gquery.py
+++ b/src/gquery.py
@@ -34,8 +34,7 @@ def guess_endpoint_uri(rq, gh_repo):
     except (TypeError, KeyError):
         # File
         try:
-            endpoint_file = gh_repo.get_contents('endpoint.txt')
-            endpoint_content = endpoint_file.decoded_content
+            endpoint_content = gh_repo.getTextFor('endpoint.txt')
             endpoint = endpoint_content.strip().splitlines()[0]
             glogger.debug("File guessed endpoint: " + endpoint)
         # TODO: except all is really ugly
@@ -208,20 +207,20 @@ def get_metadata(rq):
         # glogger.warning(traceback.print_exc())
         pass
 
-    try:
-        # insert, update query
-        glogger.info("Trying to parse udpate query")
-        parsed_query = UpdateUnit.parseString(rq, parseAll=True)
-        glogger.info(parsed_query)
-        query_metadata['type'] = parsed_query[0]['request'][0].name
-        glogger.info("Update query parsed with {}".format(query_metadata['type']))
-        # if query_metadata['type'] == 'InsertData':
-        #     query_metadata['variables'] = parsed_query.algebra['PV']
-    except:
-        glogger.error("Could not parse UPDATE query")
-        glogger.error(query_metadata['query'])
-        glogger.error(traceback.print_exc())
-        pass
+        try:
+            # insert, update query
+            glogger.info("Trying to parse update query")
+            parsed_query = UpdateUnit.parseString(rq, parseAll=True)
+            glogger.info(parsed_query)
+            query_metadata['type'] = parsed_query[0]['request'][0].name
+            glogger.info("Update query parsed with {}".format(query_metadata['type']))
+            # if query_metadata['type'] == 'InsertData':
+            #     query_metadata['variables'] = parsed_query.algebra['PV']
+        except:
+            glogger.error("Could not parse UPDATE query")
+            glogger.error(query_metadata['query'])
+            glogger.error(traceback.print_exc())
+            pass
 
     glogger.info("Finished parsing query of type {}".format(query_metadata['type']))
 

--- a/src/queryTypes.py
+++ b/src/queryTypes.py
@@ -1,0 +1,4 @@
+qType = {
+    'SPARQL': 'sparql',
+    'TPF': 'tpf'
+}

--- a/src/static.py
+++ b/src/static.py
@@ -7,9 +7,6 @@ from ConfigParser import SafeConfigParser
 DEFAULT_HOST = None
 DEFAULT_PORT = 8088
 
-# server name, used by the Flask app and in the swagger spec
-SERVER_NAME = "grlc.io"
-
 # XSD datatypes for parsing queries with parameters
 XSD_DATATYPES = ["decimal", "float", "double", "integer", "positiveInteger", "negativeInteger", "nonPositiveInteger", "nonNegativeInteger", "long", "int", "short", "byte", "unsignedLong", "unsignedInt", "unsignedShort", "unsignedByte", "dateTime", "date", "gYearMonth", "gYear", "duration", "gMonthDay", "gDay", "gMonth", "string", "normalizedString", "token", "language", "NMTOKEN", "NMTOKENS", "Name", "NCName", "ID", "IDREFS", "ENTITY", "ENTITIES", "QName", "boolean", "hexBinary", "base64Binary", "anyURI", "notation"]
 
@@ -39,3 +36,9 @@ ACCESS_TOKEN = config.get('auth', 'github_access_token')
 
 # Default endpoint, if none specified elsewhere
 DEFAULT_ENDPOINT = config.get('defaults', 'sparql_endpoint')
+
+# Local folder where queries are loaded from
+LOCAL_SPARQL_DIR = config.get('local', 'local_sparql_dir')
+
+# server name, used by the Flask app and in the swagger spec
+SERVER_NAME = config.get('defaults', 'server_name')


### PR DESCRIPTION
Addressing #80. To use local files:

Set in config.ini the key:
```local_sparql_dir = ./ ```
pointing at the local directory where grlc will look for queries.

Afterwards, run `grlc-server` and on your browser go to `/api/local`. Instead of searching for queries on github/user/repo, grlc will load queries from the specified local folder. For the rest, it works as usual.