### PR TITLE
Static enumerations

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -143,8 +143,8 @@ def process_sparql_query_text(resp, raw_query_uri, raw_repo_uri, call_name, extr
     pagination = query_metadata['pagination'] if 'pagination' in query_metadata else ""
     glogger.debug("Read query pagination: {}".format(pagination))
 
-    enums = query_metadata['enumerate'] if 'enumerate' in query_metadata else []
-    glogger.debug("Read query enumerates: {}".format(', '.join(enums)))
+    # enums = query_metadata['enumerate'] if 'enumerate' in query_metadata else []
+    # glogger.debug("Read query enumerates: {}".format(', '.join(enums)))
 
     mime = query_metadata['mime'] if 'mime' in query_metadata else ""
     glogger.debug("Read endpoint dump MIME type: {}".format(mime))
@@ -158,7 +158,7 @@ def process_sparql_query_text(resp, raw_query_uri, raw_repo_uri, call_name, extr
             parameters = gquery.get_parameters(resp, endpoint)
         except Exception as e:
             glogger.error(e)
-            glogger.error("Could not parse parameters of query {}".format(raw_query_uri))
+            glogger.error("Could not parse parameters of query {}".format(query_text))
             return None
 
         glogger.debug("Read request parameters")


### PR DESCRIPTION
Addresses #82 

This allows to specify on the header the values available in the enumeration, without querying the sparql endpoint. Header should have the following format:

```
#+ enumerate:
#+   - var:
#+     - value1
#+     - value2
#+     - value3
```

This could be useful when we want to have a list of available values (e.g. known fruits), but do not need to query the triplestore for it. For example:
```
#+ enumerate:
#+   - fruit:
#+     - apple
#+     - pear
#+     - banana
```