### PR TITLE
Add endpoint to parameter requests

### DIFF
--- a/src/gquery.py
+++ b/src/gquery.py
@@ -4,7 +4,8 @@
 
 import yaml
 from rdflib.plugins.sparql.parser import Query, UpdateUnit
-from rdflib.plugins.sparql.processor import translateQuery, translateUpdate
+from rdflib.plugins.sparql.processor import translateQuery
+from flask import request
 from pyparsing import ParseException
 import logging
 import traceback
@@ -23,15 +24,20 @@ def guess_endpoint_uri(rq, gh_repo):
     - A endpoint.txt file in the repo
     Otherwise assigns a default one
     '''
+
     endpoint = static.DEFAULT_ENDPOINT
     auth = (static.DEFAULT_ENDPOINT_USER, static.DEFAULT_ENDPOINT_PASSWORD)
     if auth == ('none','none'):
         auth = None
 
+    if "endpoint" in request.args:
+        endpoint = request.args['endpoint']
+        glogger.info("Endpoint provided in request: " + endpoint)
+        return endpoint, auth
+
     # Decorator
     try:
         decorators = get_yaml_decorators(rq)
-        glogger.debug("{}".format(decorators['endpoint']))
         endpoint = decorators['endpoint']
         auth = None
         glogger.info("Decorator guessed endpoint: " + endpoint)

--- a/src/server.py
+++ b/src/server.py
@@ -58,6 +58,9 @@ def query(user, repo, query_name, sha=None, content=None):
         raw_repo_uri = loader.getRawRepoUri()
 
         endpoint, auth = gquery.guess_endpoint_uri(raw_sparql_query, loader)
+        if endpoint=='':
+            return 'No SPARQL endpoint indicated', 407
+
         glogger.debug("=====================================================")
         glogger.debug("Sending query to SPARQL endpoint: {}".format(endpoint))
         glogger.debug("=====================================================")


### PR DESCRIPTION
Allow to provide endpoint as request url parameter. This overrides default value in config.ini and endpoint parameter on query (`#+ endpoint:`)

```
curl -X GET --header "Accept: application/json" "http://grlc.io/api/user/repo/query?endpoint=http://example.com/sparql"
```

Might be good to document this in a bit more detail.