### PR TITLE
Sparql wrapper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ rdflib==4.2.1
 rdflib-jsonld==0.4.0
 requests==2.11.1
 six==1.10.0
-SPARQLWrapper==1.7.6
 Werkzeug==0.11.3
 wheel==0.24.0
 PyGithub==1.35
+https://github.com/RDFLib/sparqlwrapper/zipball/master

--- a/src/server.py
+++ b/src/server.py
@@ -153,8 +153,8 @@ def query(user, repo, query_name, sha=None, extension=None):
 
         # Preapre HTTP request
         headers = { 'Accept' : request.headers['Accept'] , 'Authorization': 'token {}'.format(static.ACCESS_TOKEN)}
-        if content:
-            headers = { 'Accept' : static.mimetypes[content] , 'Authorization': 'token {}'.format(static.ACCESS_TOKEN)}
+        if extension:
+            headers = { 'Accept' : static.mimetypes[extension] , 'Authorization': 'token {}'.format(static.ACCESS_TOKEN)}
         tpf_list = re.split('\n|=', raw_tpf_query)
         subject = tpf_list[tpf_list.index('subject') + 1]
         predicate = tpf_list[tpf_list.index('predicate') + 1]

--- a/src/sparql.py
+++ b/src/sparql.py
@@ -6,8 +6,16 @@ SPARQL_FORMATS = {
     'application/json': JSON
 }
 
+CONTENT_EXTENSIONS = {
+    'csv': CSV,
+    'json': JSON
+}
+
 def selectReturnFormat(contentType):
     return SPARQL_FORMATS[contentType] if contentType in SPARQL_FORMATS else CSV
+
+def selectExtensionFormat(fileExtension):
+    return CONTENT_EXTENSIONS[fileExtension] if fileExtension in CONTENT_EXTENSIONS else CSV
 
 def executeSPARQLQuery(endpoint, query, retformat):
     client = SPARQLWrapper(endpoint)

--- a/src/sparql.py
+++ b/src/sparql.py
@@ -1,0 +1,21 @@
+from SPARQLWrapper import SPARQLWrapper, CSV, JSON
+from flask import jsonify
+
+SPARQL_FORMATS = {
+    'text/csv': CSV,
+    'application/json': JSON
+}
+
+def selectReturnFormat(contentType):
+    return SPARQL_FORMATS[contentType] if contentType in SPARQL_FORMATS else CSV
+
+def executeSPARQLQuery(endpoint, query, retformat):
+    client = SPARQLWrapper(endpoint)
+    client.setQuery(query)
+    client.setReturnFormat(retformat)
+    result = client.queryAndConvert()
+
+    if retformat==JSON:
+        result = jsonify(result)
+
+    return result

--- a/src/sparql.py
+++ b/src/sparql.py
@@ -1,5 +1,6 @@
 from SPARQLWrapper import SPARQLWrapper, CSV, JSON
 from flask import jsonify
+import static as static
 
 SPARQL_FORMATS = {
     'text/csv': CSV,
@@ -21,6 +22,7 @@ def executeSPARQLQuery(endpoint, query, retformat):
     client = SPARQLWrapper(endpoint)
     client.setQuery(query)
     client.setReturnFormat(retformat)
+    client.setCredentials(static.DEFAULT_ENDPOINT_USER, static.DEFAULT_ENDPOINT_PASSWORD)
     result = client.queryAndConvert()
 
     if retformat==JSON:

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,6 +7,7 @@ import traceback
 import logging
 
 from fileLoaders import GithubLoader, LocalLoader
+from sparql import SPARQL_FORMATS
 
 glogger = logging.getLogger(__name__)
 
@@ -302,7 +303,7 @@ def build_swagger_spec(user, repo, sha, serverName, prov, gh_repo):
             "tags" : item['tags'],
             "summary" : item['summary'],
             "description" : item['description'] + "\n<pre>\n{}\n</pre>".format(cgi.escape(item['query'])),
-            "produces" : ["text/csv", "application/json", "text/html"],
+            "produces" : SPARQL_FORMATS.keys(), # ["text/csv", "application/json", "text/html"],
             "parameters": item['params'] if 'params' in item else None,
             "responses": {
                 "200" : {


### PR DESCRIPTION
As it was previously discussed in #33 -- main downside was SPARQLWrapper did not support content-type CSV. Since [very recently](https://github.com/RDFLib/sparqlwrapper/commit/336532da126ca13bd4c661a89ff535994d14e97f) it does, so we can use SPARQLWrapper.

There is one advantage: we can then provide SPARQL results in all their [supported formats](https://github.com/RDFLib/sparqlwrapper/blob/master/SPARQLWrapper/Wrapper.py#L109) (HTML not supported, which we do at the moment, but that can be fixed).