### PR TITLE
 Add explicit enumerations

### DIFF
--- a/tests/repo/test-enum.rq
+++ b/tests/repo/test-enum.rq
@@ -1,0 +1,10 @@
+#+ summary: xxxxx
+#+ endpoint: http://test-endpoint/from-decorator/sparql
+#+ enumerate:
+#+   - o:
+#+     - v1
+#+     - v2
+
+SELECT * WHERE {
+ ?s ?p ?_o .
+}

--- a/tests/repo/test-enum.rq
+++ b/tests/repo/test-enum.rq
@@ -1,5 +1,4 @@
-#+ summary: xxxxx
-#+ endpoint: http://test-endpoint/from-decorator/sparql
+#+ summary: Test query for containing pre-defined enumeration.
 #+ enumerate:
 #+   - o:
 #+     - v1

--- a/tests/test_gquery.py
+++ b/tests/test_gquery.py
@@ -73,9 +73,21 @@ class TestGQuery(unittest.TestCase):
         }
 
         rq, _ = self.loader.getTextForName('test-rq')
-        enumeration = gquery.get_enumeration(rq, 'o1', 'http://mock-endpoint/sparql')
+        metadata = { 'enumerate': 'o1' }
+        enumeration = gquery.get_enumeration(rq, 'o1', 'http://mock-endpoint/sparql', metadata)
         self.assertIsInstance(enumeration, list, 'Should return a list of values')
         self.assertEquals(len(enumeration), 2, 'Should have two elements')
+
+    def test_get_static_enumeration(self):
+        rq, _ = self.loader.getTextForName('test-enum')
+
+        metadata = gquery.get_metadata(rq, '')
+        self.assertIn('enumerate', metadata, 'Should contain enumerate')
+
+        enumeration = gquery.get_enumeration(rq, 'o', 'http://mock-endpoint/sparql', metadata)
+        self.assertIsInstance(enumeration, list, 'Should return a list of values')
+        self.assertEquals(len(enumeration), 2, 'Should have two elements')
+
 
     def test_get_yaml_decorators(self):
         rq, _ = self.loader.getTextForName('test-sparql')

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -27,8 +27,8 @@ class TestGithubLoader(unittest.TestCase):
         # Should return a list of file items
         self.assertIsInstance(files, list, "Should return a list of file items")
 
-        # Should have N files (where N=4)
-        self.assertEquals(len(files), 4, "Should return correct number of files")
+        # Should have N files (where N=5)
+        self.assertEquals(len(files), 5, "Should return correct number of files")
 
         # File items should have a download_url
         for fItem in files:
@@ -82,8 +82,8 @@ class TestLocalLoader(unittest.TestCase):
         # Should return a list of file items
         self.assertIsInstance(files, list, "Should return a list of file items")
 
-        # Should have N files (where N=4)
-        self.assertEquals(len(files), 4, "Should return correct number of files")
+        # Should have N files (where N=5)
+        self.assertEquals(len(files), 5, "Should return correct number of files")
 
         # File items should have a download_url
         for fItem in files:


### PR DESCRIPTION
Refering to #114 and replacing #83 

This allows to specify on the header the values available in the enumeration, without querying the sparql endpoint. Header should have the following format:
```
#+ enumerate:
#+   - var:
#+     - value1
#+     - value2
#+     - value3
```