### PR TITLE
Endpoint url

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ If you're seeing this, your grlc instance is up and running, and ready to build 
 - To request the api-docs of your API swagger-ui style, <code>http://localhost:8088/api/username/repo/api-docs</code>, e.g. [http://localhost:8088/api/CEDAR-project/Queries/api-docs](http://localhost:8088/api/CEDAR-project/Queries/api-docs) or [http://localhost:8088/api/CLARIAH/wp4-queries/api-docs](http://localhost:8088/api/CLARIAH/wp4-queries/api-docs)
 
 By default grlc will direct your queries to the DBPedia SPARQL endpoint. To change this either:
-
-* Add a `endpoint:` decorator in the first comment block of the query text (preferred, see below)
+* Add a `endpoint` parameter to your request: 'http://grlc.io/user/repo/query?endpoint=http://sparql-endpoint/'. You can add a `#+ endpoint_in_url: False` decorator if you DO NOT want to see the `endpoint` parameter in the swagger-ui of your API.
+* Add a `#+ endpoint:` decorator in the first comment block of the query text (preferred, see below)
 * Add the URL of the endpoint on a single line in an `endpoint.txt` file within the GitHub repository that contains the queries.
 * Or you can directly modify the grlc source code (but it's nicer if the queries are self-contained)
 

--- a/src/gquery.py
+++ b/src/gquery.py
@@ -21,6 +21,7 @@ glogger = logging.getLogger(__name__)
 def guess_endpoint_uri(rq, gh_repo):
     '''
     Guesses the endpoint URI from (in this order):
+    - An endpoint parameter in URL
     - An #+endpoint decorator
     - A endpoint.txt file in the repo
     Otherwise assigns a default one

--- a/src/utils.py
+++ b/src/utils.py
@@ -197,6 +197,7 @@ def process_sparql_query_text(query_text, raw_repo_uri, call_name, extraMetadata
         endpoint_param['type'] = "string"
         endpoint_param['in'] = "query"
         endpoint_param['description'] = "Alternative endpoint for SPARQL query"
+        endpoint_param['default'] = endpoint
         params.append(endpoint_param)
 
     if query_metadata['type'] == 'SelectQuery':

--- a/src/utils.py
+++ b/src/utils.py
@@ -147,6 +147,8 @@ def process_sparql_query_text(query_text, raw_repo_uri, call_name, extraMetadata
     mime = query_metadata['mime'] if 'mime' in query_metadata else ""
     #glogger.debug("Read endpoint dump MIME type: {}".format(mime))
 
+    endpoint_in_url = query_metadata['endpoint_in_url'] if 'endpoint_in_url' in query_metadata else True
+    #glogger.debug("Read endpoint in url: {}".format(endpoint_in_url))
 
     # Processing of the parameters
     params = []
@@ -188,6 +190,14 @@ def process_sparql_query_text(query_text, raw_repo_uri, call_name, extraMetadata
                 param['enum'] = p['enum']
 
             params.append(param)
+
+    if endpoint_in_url:
+        endpoint_param = {}
+        endpoint_param['name'] = "endpoint"
+        endpoint_param['type'] = "string"
+        endpoint_param['in'] = "query"
+        endpoint_param['description'] = "Alternative endpoint for SPARQL query"
+        params.append(endpoint_param)
 
     if query_metadata['type'] == 'SelectQuery':
         # Fill in the spec for SELECT


### PR DESCRIPTION
Replacing #99. New features:

 - `endpoint` parameter can be specified on swagger-ui
 - `endpoint` parameter can on swagger-ui has default value (endpoint from decorator, endpoint.txt or default)
 - `endpoint` parameter on swagger-ui can be disabled by adding `#+ endpoint_in_url: False` decorator