### PR TITLE
Support for JSON projections

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ six==1.11.0
 SPARQLWrapper==1.8.2
 Werkzeug==0.14.1
 PyGithub==1.35
-pythonql==0.9.51;python_version<"2.7"
-pythonql3==0.9.61;python_version>"3.5"
+pythonql==0.9.51;python_version>="2.7"
+pythonql3==0.9.61;python_version>="3.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ six==1.11.0
 SPARQLWrapper==1.8.2
 Werkzeug==0.14.1
 PyGithub==1.35
-pythonql==0.9.51;python_version>="2.7"
+pythonql==0.9.51;python_version<"3.5"
 pythonql3==0.9.61;python_version>="3.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ six==1.11.0
 SPARQLWrapper==1.8.2
 Werkzeug==0.14.1
 PyGithub==1.35
+pythonql==0.9.51

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ six==1.11.0
 SPARQLWrapper==1.8.2
 Werkzeug==0.14.1
 PyGithub==1.35
-pythonql==0.9.51
+pythonql==0.9.51;python_version<"2.7"
+pythonql3==0.9.61;python_version>"3.5"

--- a/src/fileLoaders.py
+++ b/src/fileLoaders.py
@@ -26,6 +26,15 @@ class BaseLoader:
         # No query found...
         return '', None
 
+    def getProjectionForQueryName(self, query_name):
+        ''' TODO: DOCUMENT !!
+        Returns None if no such projection exists
+        '''
+        projectionFileName = query_name + '.pyql'
+        projectionText = self._getText(projectionFileName)
+        return projectionText
+
+
 class GithubLoader(BaseLoader):
     def __init__(self, user, repo, sha, prov):
         self.user = user

--- a/src/fileLoaders.py
+++ b/src/fileLoaders.py
@@ -1,11 +1,10 @@
-import static as static
-import requests
+import grlc.static as static
+from grlc.queryTypes import qType
 
+import requests
 from os import path
 from glob import glob
 from github import Github
-
-from queryTypes import qType
 
 class BaseLoader:
     def getTextForName(self, query_name):

--- a/src/gquery.py
+++ b/src/gquery.py
@@ -318,7 +318,7 @@ def rewrite_query(query, parameters, get_args):
     requireXSD = False
 
     required_params = {}
-    for k,v in parameters.iteritems():
+    for k,v in parameters.items():
         if parameters[k]['required']:
             required_params[k] = v
     requiredParams = set(required_params.keys())

--- a/src/gquery.py
+++ b/src/gquery.py
@@ -14,7 +14,7 @@ import re
 import requests
 
 # grlc modules
-import static as static
+import grlc.static as static
 
 glogger = logging.getLogger(__name__)
 

--- a/src/projection.py
+++ b/src/projection.py
@@ -1,0 +1,24 @@
+import logging
+from pythonql.parser.Preprocessor import makeProgramFromString
+
+glogger = logging.getLogger(__name__)
+
+def project(dataIn, projectionScript):
+    '''Programs may make use of data in the `dataIn` variable and should
+    produce data on the `dataOut` variable.'''
+    # We don't really need to initialize it, but we do it to avoid linter errors
+    dataOut = {}
+    try:
+        projectionScript = str(projectionScript)
+        program = makeProgramFromString(projectionScript)
+        exec(program)
+    except Exception as e:
+        glogger.error("Error while executing SPARQL projection")
+        glogger.error(projectionScript)
+        glogger.error("Encountered exception: ")
+        glogger.error(e)
+        dataOut = {
+            'status': 'error',
+            'message': e.message
+        }
+    return dataOut

--- a/src/projection.py
+++ b/src/projection.py
@@ -1,5 +1,6 @@
 import logging
 from pythonql.parser.Preprocessor import makeProgramFromString
+from six import PY3
 
 glogger = logging.getLogger(__name__)
 
@@ -11,7 +12,15 @@ def project(dataIn, projectionScript):
     try:
         projectionScript = str(projectionScript)
         program = makeProgramFromString(projectionScript)
-        exec(program)
+        if PY3:
+            loc = {
+                'dataIn': dataIn,
+                'dataOut': dataOut
+            }
+            exec(program, {}, loc)
+            dataOut = loc['dataOut']
+        else:
+            exec(program)
     except Exception as e:
         glogger.error("Error while executing SPARQL projection")
         glogger.error(projectionScript)

--- a/src/prov.py
+++ b/src/prov.py
@@ -6,10 +6,10 @@ from rdflib import Graph, URIRef, Namespace, RDF, Literal
 import logging
 from datetime import datetime
 from subprocess import check_output
+from six import PY3
 
 # grlc modules
-import static as static
-from six import PY3
+import grlc.static as static
 
 glogger = logging.getLogger(__name__)
 

--- a/src/prov.py
+++ b/src/prov.py
@@ -3,13 +3,13 @@
 # prov.py: class generating grlc related W3C prov triples
 
 from rdflib import Graph, URIRef, Namespace, RDF, Literal
-from rdflib.plugins.parsers.notation3 import BadSyntax
 import logging
 from datetime import datetime
 from subprocess import check_output
 
 # grlc modules
 import static as static
+from six import PY3
 
 glogger = logging.getLogger(__name__)
 
@@ -92,4 +92,7 @@ class grlcPROV():
         '''
         Serialize provenance graph in the specified format
         '''
-        return self.prov_g.serialize(format=format)
+        if PY3:
+            return self.prov_g.serialize(format=format).decode('utf-8')
+        else:
+            return self.prov_g.serialize(format=format)

--- a/src/server.py
+++ b/src/server.py
@@ -6,8 +6,8 @@ from flask import Flask, request, jsonify, render_template, make_response
 import logging
 
 # grlc modules
-import static as static
-import utils as utils
+import grlc.static as static
+import grlc.utils as utils
 
 # The Flask app
 app = Flask(__name__)

--- a/src/sparql.py
+++ b/src/sparql.py
@@ -1,8 +1,12 @@
+import logging
+
 from SPARQLWrapper import SPARQLWrapper, CSV, JSON
 from flask import jsonify
 from collections import defaultdict
 
 import static as static
+
+glogger = logging.getLogger(__name__)
 
 # Default value is JSON
 SUPPORTED_MIME_FORMATS = defaultdict(

--- a/src/static.py
+++ b/src/static.py
@@ -2,7 +2,10 @@
 
 # static.py: static values for the grlc Server
 
-from configparser import SafeConfigParser
+try:
+    from ConfigParser import SafeConfigParser
+except:
+    from configparser import SafeConfigParser
 
 DEFAULT_HOST = None
 DEFAULT_PORT = 8088

--- a/src/static.py
+++ b/src/static.py
@@ -2,7 +2,7 @@
 
 # static.py: static values for the grlc Server
 
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 
 DEFAULT_HOST = None
 DEFAULT_PORT = 8088

--- a/src/swagger.py
+++ b/src/swagger.py
@@ -1,6 +1,6 @@
-import utils
-import gquery
-import pagination as pageUtils
+import grlc.utils
+import grlc.gquery as gquery
+import grlc.pagination as pageUtils
 
 import traceback
 import logging
@@ -20,7 +20,7 @@ def get_blank_spec():
 
 def get_repo_info(user, repo, sha, prov_g):
     '''Generate swagger information from the repo being used.'''
-    loader = utils.getLoader(user, repo, sha, prov_g)
+    loader = grlc.utils.getLoader(user, repo, sha, prov_g)
 
     user_repo = loader.getFullName()
     repo_title = loader.getRepoTitle()
@@ -97,7 +97,7 @@ def get_path_for_item(item):
 
 def build_spec(user, repo, sha=None, prov=None, extraMetadata=[]):
     '''Build grlc specification for the given github user / repo.'''
-    loader = utils.getLoader(user, repo, sha=sha, prov=prov)
+    loader = grlc.utils.getLoader(user, repo, sha=sha, prov=prov)
 
     files = loader.fetchFiles()
     raw_repo_uri = loader.getRawRepoUri()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,11 +1,11 @@
-import static as static
-import gquery as gquery
-import pagination as pageUtils
-import swagger as swagger
-from prov import grlcPROV
-from fileLoaders import GithubLoader, LocalLoader
-from queryTypes import qType
-from projection import project
+import grlc.static as static
+import grlc.gquery as gquery
+import grlc.pagination as pageUtils
+import grlc.swagger as swagger
+from grlc.prov import grlcPROV
+from grlc.fileLoaders import GithubLoader, LocalLoader
+from grlc.queryTypes import qType
+from grlc.projection import project
 from grlc import __version__ as grlc_version
 
 import re

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,10 +5,12 @@ import swagger as swagger
 from prov import grlcPROV
 from fileLoaders import GithubLoader, LocalLoader
 from queryTypes import qType
+from projection import project
 from grlc import __version__ as grlc_version
 
 import re
 import requests
+import json
 import logging
 
 from rdflib import Graph
@@ -69,6 +71,14 @@ def dispatch_query(user, repo, query_name, sha=None, content=None, requestArgs={
     # Call name implemented with SPARQL query
     if q_type == qType['SPARQL']:
         resp, status, headers = dispatchSPARQLQuery(query, loader, requestArgs, acceptHeader, content, formData, requestUrl)
+
+        if acceptHeader == 'application/json':
+            projection = loader.getProjectionForQueryName(query_name)
+            if projection:
+                dataIn = json.loads(resp)
+                dataOut = project(dataIn, projection)
+                resp = json.dumps(dataOut)
+
         return resp, status, headers
     # Call name implemented with TPF query
     elif q_type == qType['TPF']:

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -30,3 +30,50 @@ def mock_requestsGithub(uri, headers={}, params={}):
         else:
             return_value = Mock(status_code=404)
             return return_value
+
+mock_sparqlResponse = {
+  "head": {
+    "link": [],
+    "vars": [ "country_name", "capital_name", "population" ]
+  },
+  "results": {
+    "distinct": "false",
+    "ordered": "true",
+    "bindings": [
+      {
+        "country_name": {
+          "type": "literal",
+          "xml:lang": "en",
+          "value": "Albania"
+        },
+        "capital_name": {
+          "type": "literal",
+          "xml:lang": "en",
+          "value": "Tirana"
+        },
+        "population": {
+          "type": "typed-literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#nonNegativeInteger",
+          "value": "2886026"
+        }
+      },
+      {
+        "country_name": {
+          "type": "literal",
+          "xml:lang": "en",
+          "value": "Algeria"
+        },
+        "capital_name": {
+          "type": "literal",
+          "xml:lang": "en",
+          "value": "Algiers"
+        },
+        "population": {
+          "type": "typed-literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#nonNegativeInteger",
+          "value": "40400000"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_gquery.py
+++ b/tests/test_gquery.py
@@ -35,7 +35,7 @@ class TestGQuery(unittest.TestCase):
         rq, _ = self.loader.getTextForName('test-rq')
 
         params = gquery.get_parameters(rq, '', '', {})
-        for paramName, param in params.iteritems():
+        for paramName, param in params.items():
             self.assertIn('name', param, 'Should have a name')
             self.assertIn('type', param, 'Should have a type')
             self.assertIn('required', param, 'Should have a required')
@@ -175,11 +175,7 @@ class TestGQuery(unittest.TestCase):
         # carefully constructed, but that is not the scope of this test
         rq_rw = gquery.rewrite_query(rq, parameters, args)
 
-        for pName, pValue in parameters.iteritems():
-            print 'pName : ',pName
-            print 'pValue: ',pValue
-            print 'rq    : ',rq
-            print 'rq_rw  : ',rq_rw
+        for pName, pValue in parameters.items():
             self.assertIn(
                 pName, rq, 'Original query should contain original parameter name')
             self.assertNotIn(

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,0 +1,36 @@
+import unittest
+
+from grlc.projection import project
+
+from tests.mock_data import mock_sparqlResponse
+
+class TestProjection(unittest.TestCase):
+    def xtest_project_error(self):
+        projectionScript = 'This projection script has invalid syntax'
+        projection = project(mock_sparqlResponse, projectionScript)
+        self.assertIn('status', projection, 'Should contain a status')
+        self.assertEqual(projection['status'], 'error', 'Status should be error')
+
+    def test_project_success_simple(self):
+        projectionScript = 'dataOut = {}\n'
+        projection = project(mock_sparqlResponse, projectionScript)
+        self.assertIsInstance(projection, dict)
+        self.assertEqual(projection, {})
+
+    def test_project_success_not_so_simple(self):
+        projectionScript = '''
+from pythonql.Executor import *
+
+dataOut = [
+    select (country, capital)
+    for item in dataIn['results']['bindings']
+    let country = item['country_name']['value']
+    let capital = item['capital_name']['value']
+]
+        '''
+        projection = project(mock_sparqlResponse, projectionScript)
+        self.assertIsInstance(projection, list, 'Projection should be a list')
+        for item in projection:
+            itemDict = item.getDict()
+            self.assertIn('country', itemDict, 'List items should contain a country')
+            self.assertIn('capital', itemDict, 'List items should contain a capital')

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -3,6 +3,7 @@
 import unittest
 from mock import patch
 
+import grlc.utils # BUG: grlc.swagger will not import without this import first
 from grlc.swagger import build_spec
 
 def mock_process_sparql_query_text(query_text, raw_repo_uri, call_name, extraMetadata):


### PR DESCRIPTION
New feature, [discussed long ago](https://github.com/SparqlProjections/TestSuite) this PR adds the possibility of adding *projections* for JSON results. This gives the user the possibility of providing a pythonql script which will transform the JSON coming from the triplestore into a different format.

An [example repo](https://github.com/c-martinez/grlc-queries) is provided. Query `dbpediaCapitalsLocation` fetches from dbpedia location of country capitals. `dbpediaCapitalsLocation.pyql` transforms the result to a GeoJSON file.

Calling this endpoint

```curl -X GET "http://localhost:8088/api/c-martinez/grlc-queries/dbpediaCapitalsLocation" -H "accept: application/json"```

Would usually return something like this:

```json
{
  "head": {
    "link": [],
    "vars": [
      "country_name",
      "capital_name",
      "population",
      "lat",
      "long"
    ]
  },
  "results": {
    "distinct": false,
    "ordered": true,
    "bindings": [
      {
        "country_name": {
          "type": "literal",
          "xml:lang": "en",
          "value": "Algeria"
        },
...
}
```

With the new projection functionality, it would return something like this:
```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "geometry": {
        "type": "Point",
        "coordinates": [
          3.21667,
          36.7667
        ]
      },
      "type": "Feature",
      "properties": {
        "name": "Algeria, Algiers",
        "population": "40400000"
      }
    },
    {
      "geometry": {
        "type": "Point",
        "coordinates": [
          49.8822,
          40.3953
        ]
      },
      "type": "Feature",
      "properties": {
        "name": "Azerbaijan, Baku",
        "population": "9754830"
      }
...
}
```

Comments?