### PR TITLE
configuration in json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ docker-compose.yml
 bin/
 !bin/grlc-server
 share/
+.idea
+.pytest_cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ isodate==0.5.4
 itsdangerous==1.1.0
 keepalive==0.5
 MarkupSafe==0.23
-pyaml==15.8.2
+pyaml==18.11.0
 pyparsing==2.0.7
 PyYAML==3.13
 rdflib==4.2.1
@@ -15,7 +15,7 @@ rdflib-jsonld==0.4.0
 requests==2.20.0
 six==1.11.0
 SPARQLWrapper==1.8.2
-SPARQLTransformer==1.6.8
+SPARQLTransformer==1.6.10
 Werkzeug==0.14.1
 PyGithub==1.35
 pythonql==0.9.51;python_version<"3.5"

--- a/tests/repo/test-json.json
+++ b/tests/repo/test-json.json
@@ -11,5 +11,16 @@
     "dbo": "http://dbpedia.org/ontology/"
   },
   "$limit": 100,
-  "grlc": "#+ summary: Testing DBpedia endpoint\n#+ endpoint: http://dbpedia.org/sparql\n#+ tags:\n#+   - dbpedia\n#+ method: GET\n#+ pagination: 50\n#+ defaults:\n#+   - type: http://dbpedia.org/ontology/Band"
+  "grlc": {
+    "summary": "Testing DBpedia endpoint",
+    "endpoint": "http://dbpedia.org/sparql",
+    "tags": [
+      "dbpedia"
+    ],
+    "method": "GET",
+    "pagination": 50,
+    "defaults": {
+      "type": "http://dbpedia.org/ontology/Band"
+    }
+  }
 }

--- a/tests/repo/test-sparql-jsonconf.sparql
+++ b/tests/repo/test-sparql-jsonconf.sparql
@@ -1,0 +1,18 @@
+#+ {
+#+  "summary": "Different types of annotations Adding extra text Just because summaries can be long.",
+#+  "tags": [
+#+    "firstTag",
+#+    "secondTag"
+#+  ],
+#+  "endpoint": "http://example.com/sparql",
+#+  "method": "GET",
+#+  "pagination": 100,
+#+  "enumerate": [
+#+    "var1",
+#+    "var2"
+#+  ]
+#+ }
+SELECT * 
+WHERE {
+    ?s ?p ?o
+}

--- a/tests/test_gquery.py
+++ b/tests/test_gquery.py
@@ -4,9 +4,8 @@ import rdflib
 from mock import patch, Mock
 
 from grlc.fileLoaders import LocalLoader
-from grlc import gquery
+import grlc.gquery as gquery
 import grlc.utils as utils
-from SPARQLTransformer import sparqlTransformer
 
 from flask import Flask
 
@@ -93,6 +92,25 @@ class TestGQuery(unittest.TestCase):
 
     def test_get_yaml_decorators(self):
         rq, _ = self.loader.getTextForName('test-sparql')
+
+        decorators = gquery.get_yaml_decorators(rq)
+
+        # Query always exist -- the rest must be present on the file.
+        self.assertIn('query', decorators, 'Should have a query field')
+        self.assertIn('summary', decorators, 'Should have a summary field')
+        self.assertIn('pagination', decorators,
+                      'Should have a pagination field')
+        self.assertIn('enumerate', decorators, 'Should have a enumerate field')
+
+        self.assertIsInstance(
+            decorators['summary'], six.string_types, 'Summary should be text')
+        self.assertIsInstance(
+            decorators['pagination'], int, 'Pagination should be numeric')
+        self.assertIsInstance(
+            decorators['enumerate'], list, 'Enumerate should be a list')
+
+    def test_get_json_decorators(self):
+        rq, _ = self.loader.getTextForName('test-sparql-jsonconf')
 
         decorators = gquery.get_yaml_decorators(rq)
 


### PR DESCRIPTION
The decorator can now be written both in YAML or JSON.

Moreover `pyaml` has been updated for avoiding deprecation (sopping to work in python 3.8)
