### PR TITLE
Project transform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ requests==2.20.0
 six==1.11.0
 simplejson==3.16.0
 setuptools>=38.6.0
-SPARQLTransformer==1.6.10
+SPARQLTransformer==1.7.0
 SPARQLWrapper==1.8.2
 Werkzeug==0.14.1
 PyGithub==1.43.5

--- a/src/utils.py
+++ b/src/utils.py
@@ -179,8 +179,6 @@ def dispatchSPARQLQuery(raw_sparql_query, loader, requestArgs, acceptHeader, con
 
     # If there's no mime type, the endpoint is an actual SPARQL endpoint
     else:
-        # requestedMimeType = static.mimetypes[content] if content else acceptHeader
-        # result, contentType = sparql.getResponseText(endpoint, query, requestedMimeType)
         reqHeaders = {'Accept': acceptHeader}
         if content:
             reqHeaders = {'Accept': static.mimetypes[content]}
@@ -206,6 +204,11 @@ def dispatchSPARQLQuery(raw_sparql_query, loader, requestArgs, acceptHeader, con
 
     if 'proto' in query_metadata:  # sparql transformer
         resp = SPARQLTransformer.post_process(json.loads(resp), query_metadata['proto'], query_metadata['opt'])
+
+    if 'transform' in query_metadata:  # sparql transformer
+        rq = { 'proto': query_metadata['transform'] }
+        _, _, opt = SPARQLTransformer.pre_process(rq)
+        resp = SPARQLTransformer.post_process(json.loads(resp), query_metadata['transform'], opt)
 
     headers['Server'] = 'grlc/' + grlc_version
     return resp, 200, headers

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -31,6 +31,19 @@ def mock_requestsGithub(uri, headers={}, params={}):
             return_value = Mock(status_code=404)
             return return_value
 
+mock_simpleSparqlResponse = {
+    "head": { "link": [], "vars": ["p", "o"] },
+    "results": {
+        "bindings": [
+            { "p": { "type": "string", "value": "p1" }	, "o": { "type": "string", "value": "o1" }},
+            { "p": { "type": "string", "value": "p2" }	, "o": { "type": "string", "value": "o2" }},
+            { "p": { "type": "string", "value": "p3" }	, "o": { "type": "string", "value": "o3" }},
+            { "p": { "type": "string", "value": "p4" }	, "o": { "type": "string", "value": "o4" }},
+            { "p": { "type": "string", "value": "p5" }	, "o": { "type": "string", "value": "o5" }}
+        ]
+    }
+}
+
 mock_sparqlResponse = {
   "head": {
     "link": [],

--- a/tests/repo/test-projection.rq
+++ b/tests/repo/test-projection.rq
@@ -1,8 +1,9 @@
 #+ summary: Sample query for testing response transformation
 #+ endpoint: "http://test-endpoint/transform/sparql/"
 #+ transform: {
-#+     "id": "?p",
-#+     "value": "?o"
+#+     "key": "?p",
+#+     "value": "?o",
+#+     "$anchor": "key"
 #+   }
 
 select ?p ?o where {

--- a/tests/repo/test-projection.rq
+++ b/tests/repo/test-projection.rq
@@ -1,0 +1,10 @@
+#+ summary: Sample query for testing response transformation
+#+ endpoint: "http://test-endpoint/transform/sparql/"
+#+ transform: {
+#+     "id": "?p",
+#+     "value": "?o"
+#+   }
+
+select ?p ?o where {
+  ?_id_iri ?p ?o
+} LIMIT 5

--- a/tests/test_gquery.py
+++ b/tests/test_gquery.py
@@ -2,12 +2,9 @@ import unittest
 import six
 import rdflib
 from mock import patch, Mock
-import json
 
 from grlc.fileLoaders import LocalLoader
 import grlc.gquery as gquery
-import grlc.utils as utils
-from tests.mock_data import mock_simpleSparqlResponse
 
 from flask import Flask
 
@@ -206,85 +203,6 @@ class TestGQuery(unittest.TestCase):
                 pValue['name'], rq, 'Original query should not contain replacement parameter value')
             self.assertIn(
                 pValue['name'], rq_rw, 'Rewritten query should contain replacement parameter value')
-
-    @patch('requests.get')
-    def test_sparql_transformer(self, mock_get):
-        mock_json = {
-            "head": {},
-            "results": {
-                "bindings": [
-                    {
-                        "id": {
-                            "type": "uri",
-                            "value": "http://www.w3.org/2001/XMLSchema#anyURI"
-                        },
-                        "class": {
-                            "type": "uri",
-                            "value": "http://www.w3.org/2000/01/rdf-schema#Datatype"
-                        },
-                        "v2": {
-                            "type": "literal",
-                            "xml:lang": "en",
-                            "value": "xsd:anyURI"
-                        }
-                    },
-                    {
-                        "id": {
-                            "type": "uri",
-                            "value": "http://www.w3.org/2001/XMLSchema#boolean"
-                        },
-                        "class": {
-                            "type": "uri",
-                            "value": "http://www.w3.org/2000/01/rdf-schema#Datatype"
-                        },
-                        "v2": {
-                            "type": "literal",
-                            "xml:lang": "en",
-                            "value": "xsd:boolean"
-                        }
-                    }]
-            }
-        }
-
-        mock_get.return_value = Mock(ok=True)
-        mock_get.return_value.headers = {'Content-Type': 'application/json'}
-        mock_get.return_value.text = json.dumps(mock_json)
-
-        rq, _ = self.loader.getTextForName('test-json')
-
-        self.assertIn('proto', rq)
-
-        resp, status, headers = utils.dispatchSPARQLQuery(rq, self.loader, content=None, requestArgs={},
-                                                          acceptHeader='application/json',
-                                                          requestUrl='http://mock-endpoint/sparql', formData={})
-        self.assertEqual(status, 200)
-        self.assertIsInstance(resp, list)
-        self.assertIn('http', resp[0]['id'])
-
-    @patch('requests.get')
-    def test_projection(self, mock_get):
-        mock_json = mock_simpleSparqlResponse
-
-        mock_get.return_value = Mock(ok=True)
-        mock_get.return_value.headers = {'Content-Type': 'application/json'}
-        mock_get.return_value.text = json.dumps(mock_json)
-
-        rq, _ = self.loader.getTextForName('test-projection')
-        resp, status, headers = utils.dispatchSPARQLQuery(rq, self.loader, content=None, requestArgs={'id': 'http://dbpedia.org/resource/Frida_Kahlo'},
-                                                          acceptHeader='application/json',
-                                                          requestUrl='http://mock-endpoint/sparql', formData={})
-
-        self.assertIsInstance(resp, list, 'Response should be a list')
-        self.assertEqual(len(resp), 5, 'Response should have 5 entries')
-        for item in resp:
-            self.assertTrue('id' in item, 'Response items should contain an id')
-            self.assertTrue('value' in item, 'Response items should contain a value')
-        ids = [ item['id'] for item in resp ]
-
-        values = [ item['value'] for item in resp ]
-
-        self.assertTrue(all(i in ids for i in ['p1', 'p2', 'p3', 'p4', 'p5']), 'Response should contain all known ids')
-        self.assertTrue(all(v in values for v in ['o1', 'o2', 'o3', 'o4', 'o5']), 'Response should contain all known values')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -30,8 +30,8 @@ class TestGithubLoader(unittest.TestCase):
         # Should return a list of file items
         self.assertIsInstance(files, list, "Should return a list of file items")
 
-        # Should have N files (where N=7)
-        self.assertEquals(len(files), 7, "Should return correct number of files")
+        # Should have N files (where N=8)
+        self.assertEquals(len(files), 8, "Should return correct number of files")
 
         # File items should have a download_url
         for fItem in files:
@@ -86,8 +86,8 @@ class TestLocalLoader(unittest.TestCase):
         # Should return a list of file items
         self.assertIsInstance(files, list, "Should return a list of file items")
 
-        # Should have N files (where N=7)
-        self.assertEquals(len(files), 7, "Should return correct number of files")
+        # Should have N files (where N=8)
+        self.assertEquals(len(files), 8, "Should return correct number of files")
 
         # File items should have a download_url
         for fItem in files:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,89 @@
+import unittest
+from mock import patch, Mock
+import json
+
+from grlc.fileLoaders import LocalLoader
+import grlc.utils as utils
+
+from tests.mock_data import mock_simpleSparqlResponse
+
+class TestUtils(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.loader = LocalLoader('./tests/repo/')
+
+    @patch('requests.get')
+    def test_sparql_transformer(self, mock_get):
+        mock_json = {
+            "head": {},
+            "results": {
+                "bindings": [
+                    {
+                        "id": {
+                            "type": "uri",
+                            "value": "http://www.w3.org/2001/XMLSchema#anyURI"
+                        },
+                        "class": {
+                            "type": "uri",
+                            "value": "http://www.w3.org/2000/01/rdf-schema#Datatype"
+                        },
+                        "v2": {
+                            "type": "literal",
+                            "xml:lang": "en",
+                            "value": "xsd:anyURI"
+                        }
+                    },
+                    {
+                        "id": {
+                            "type": "uri",
+                            "value": "http://www.w3.org/2001/XMLSchema#boolean"
+                        },
+                        "class": {
+                            "type": "uri",
+                            "value": "http://www.w3.org/2000/01/rdf-schema#Datatype"
+                        },
+                        "v2": {
+                            "type": "literal",
+                            "xml:lang": "en",
+                            "value": "xsd:boolean"
+                        }
+                    }]
+            }
+        }
+
+        mock_get.return_value = Mock(ok=True)
+        mock_get.return_value.headers = {'Content-Type': 'application/json'}
+        mock_get.return_value.text = json.dumps(mock_json)
+
+        rq, _ = self.loader.getTextForName('test-json')
+
+        self.assertIn('proto', rq)
+
+        resp, status, headers = utils.dispatchSPARQLQuery(rq, self.loader, content=None, requestArgs={},
+                                                          acceptHeader='application/json',
+                                                          requestUrl='http://mock-endpoint/sparql', formData={})
+        self.assertEqual(status, 200)
+        self.assertIsInstance(resp, list)
+        self.assertIn('http', resp[0]['id'])
+
+    @patch('requests.get')
+    def test_projection(self, mock_get):
+        mock_get.return_value = Mock(ok=True)
+        mock_get.return_value.headers = {'Content-Type': 'application/json'}
+        mock_get.return_value.text = json.dumps(mock_simpleSparqlResponse)
+
+        rq, _ = self.loader.getTextForName('test-projection')
+        resp, status, headers = utils.dispatchSPARQLQuery(rq, self.loader, content=None, requestArgs={'id': 'http://dbpedia.org/resource/Frida_Kahlo'},
+                                                          acceptHeader='application/json',
+                                                          requestUrl='http://mock-endpoint/sparql', formData={})
+
+        self.assertIsInstance(resp, list, 'Response should be a list')
+        self.assertEqual(len(resp), 5, 'Response should have 5 entries')
+        for item in resp:
+            self.assertTrue('key' in item, 'Response items should contain a key')
+            self.assertTrue('value' in item, 'Response items should contain a value')
+        keys = [ item['key'] for item in resp ]
+        values = [ item['value'] for item in resp ]
+
+        self.assertTrue(all(k in keys for k in ['p1', 'p2', 'p3', 'p4', 'p5']), 'Response should contain all known keys')
+        self.assertTrue(all(v in values for v in ['o1', 'o2', 'o3', 'o4', 'o5']), 'Response should contain all known values')


### PR DESCRIPTION
Implementing functionality discussed in #215 (requires the freshly released `SPARQLTransform==1.7.0`)

SPARQLTransform syntax can be included in the grlc decorator header `transform`. Response will be transformed according to that syntax, while query can still be SPARQL and keep he full expressiveness of SPARQL.

I think we can get rid of the old pyql projections (of which I think I was the only user) and of the json query syntax. What do you think @albertmeronyo & @pasqLisena ?