### PR TITLE
removing unnecessary import that causes a cyclic importing error 

### DIFF
--- a/src/swagger.py
+++ b/src/swagger.py
@@ -1,5 +1,4 @@
 import json
-import grlc.utils
 import grlc.gquery as gquery
 import grlc.pagination as pageUtils
 


### PR DESCRIPTION
This error happens in certain cases and prevents me from deploying grlc (as a lib) as part of my search API (on our servers; locally it works somehow).

To circumvent [this issue](https://github.com/CLARIAH/grlc/issues/223) I managed to install grlc as follows:

```
pipenv install (I excluded grlc from my Pipfile to prevent issue 223)
pip install grlc
```

Then I had to copy my `config.ini` to the VENV/lib/python3.x/site-packages/grlc/config.ini to make sure it works for my code (grlc used to be able to find the config.ini in the root of my code. Would really appreciate the option to configure the location of the config.ini).

After that I noticed things were still not working because of this cyclic import error. For now I fixed this within the grlc code on the server...

So appreciated if this can be merged soon, so I can deploy it fully automatically (I use Puppet)

Cheers

