### PR TITLE
Use relative paths for swagger spec

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -27,7 +27,7 @@ def grlc():
 # Spec generation, front-end
 @app.route('/api-local', methods=['GET'], strict_slashes=False)
 def api_docs_local():
-    return render_template('api-docs.html', swagger_url='/api-local/swagger')
+    return render_template('api-docs.html', relative_path=relative_path())
 
 # Spec generation, JSON
 @app.route('/api-local/swagger', methods=['GET'])
@@ -57,7 +57,7 @@ def api_docs_param():
     # Get queries provided by params
     spec_url = request.args['specUrl']
     glogger.info("Spec URL: ".format(spec_url))
-    return render_template('api-docs.html', swagger_url='/api-url/swagger?specUrl=' + spec_url)
+    return render_template('api-docs.html', relative_path=relative_path())
 
 # Spec generation, JSON
 @app.route('/api-url/swagger', methods=['GET'])
@@ -108,13 +108,7 @@ def query(user, repo, query_name, subdir=None, spec_url=None, sha=None, content=
 @app.route('/api-git/<user>/<repo>/<subdir>/commit/<sha>')
 @app.route('/api-git/<user>/<repo>/<subdir>/commit/<sha>/api-docs')
 def api_docs(user, repo, subdir=None, spec_url=None, sha=None):
-    swagger_url = '/api-git/{}/{}'.format(user, repo)
-    if subdir:
-        swagger_url += '/{}'.format(subdir)
-    if sha:
-        swagger_url += '/commit/{}'.format(sha)
-    swagger_url += '/swagger'
-    return render_template('api-docs.html', swagger_url=swagger_url)
+    return render_template('api-docs.html', relative_path=relative_path())
 
 # Spec generation, JSON
 @app.route('/api-git/<user>/<repo>/swagger', methods=['GET'])
@@ -138,6 +132,10 @@ def swagger_spec(user, repo, subdir=None, spec_url=None, sha=None, content=None)
     glogger.info("-----> API spec generation for /{}/{}, subdir {}, params {}, on commit {} complete".format(user, repo, subdir, spec_url, sha))
     return resp_spec
 
+def relative_path():
+    path = request.path
+    path = '.' + '/..' * (path.count('/') - 1)
+    return path
 
 
 # Main thread

--- a/src/static/js/grlc-api.js
+++ b/src/static/js/grlc-api.js
@@ -95,10 +95,16 @@ function grlcProvToggle(e){
  * Called when window is fully loaded. It then triggers creation of SwaggerUIBundle.
  *
  */
-function grlcOnLoad(url) {
+function grlcOnLoad() {
   // Build a system
+  let url = document.location.pathname;
+  if( ! url.endsWith("/")) {
+    url += "/";
+  }
+  swagger_url = url + "swagger" + document.location.search;
+  console.log('swagger_url: ' + swagger_url);
   const ui = SwaggerUIBundle({
-    url: url,
+    url: swagger_url,
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/src/templates/api-docs.html
+++ b/src/templates/api-docs.html
@@ -5,7 +5,7 @@
     <title>grlc</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.17.1/swagger-ui.css" >
-    <link rel="icon" href="{{url_for('.static', filename='favicon.ico', _external=True)}}">
+    <link rel="icon" href="{{ relative_path + url_for('.static', filename='favicon.ico')}}">
     <style>
       html
       {
@@ -44,7 +44,7 @@
       <div class="swagger-ui">
         <div class="topbar">
           <a class="link" href="https://github.com/CLARIAH/grlc">
-            <img height="50" width="50"  alt="grlc" src="{{url_for('.static', filename='grlc_logo_02.png', _external=True)}}">
+            <img height="50" width="50"  alt="grlc" src="{{ relative_path + url_for('.static', filename='grlc_logo_02.png')}}">
             <span>grlc</span>
           </a>
         </div>
@@ -85,13 +85,11 @@
 
     <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
 
-    <script src="{{url_for('.static', filename='js/grlc-layout.js', _external=True)}}"></script>
-    <script src="{{url_for('.static', filename='js/grlc-api.js', _external=True)}}"></script>
+    <script src="{{ relative_path + url_for('.static', filename='js/grlc-layout.js')}}"></script>
+    <script src="{{ relative_path + url_for('.static', filename='js/grlc-api.js')}}"></script>
 
     <script>
-      console.log("{{query_urls}}");
-      url = "{{swagger_url}}";
-      window.onload = grlcOnLoad(url);
+      window.onload = grlcOnLoad();
       $('#prev-commit').hide();
       $('#next-commit').hide();
       $('#ohyeahdiv').hide();

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -8,12 +7,12 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <meta name="description" content="grlc generates RESTful APIs using SPARQL queries stored in GitHub repositories">
     <meta name="author" content="Albert Meroño Peñuela">
-    <link rel="shortcut icon" href="{{ url_for('.static', filename='favicon.ico', _external=True)}}">
+    <link rel="shortcut icon" href=".{{ url_for('.static', filename='favicon.ico')}}">
 
     <title>grlc</title>
 
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
-    <link href="{{ url_for('.static', filename='css/grlc.css', _external=True)}}" rel="stylesheet">
+    <link href=".{{ url_for('.static', filename='css/grlc.css')}}" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -55,7 +54,7 @@
           </div>
 
           <div class="inner cover" style="margin-top: 30px">
-	    <img src="{{ url_for('.static', filename='grlc_logo_01.png', _external=True)}}" >
+	    <img src=".{{ url_for('.static', filename='grlc_logo_01.png')}}" >
             <p class="lead"> <b>grlc</b> makes all your <a href="https://www.w3.org/DesignIssues/LinkedData.html" target="_blank">Linked Data</a> accessible to the Web by automatically converting your SPARQL queries into RESTful APIs. With (almost) no effort! Simply: </p>
 	    <p class="lead circ-number">1</p>
 	    <p class="lead smaller">Create a GitHub repository, and store all your SPARQL queries in there (like in <a href="https://github.com/CEDAR-project/Queries" target="_blank">this example</a>). If you don't have a GitHub account, <a href="https://github.com/join">go get one</a>. You can also just write down the username and the repository name of somebody else :-)</p>
@@ -63,7 +62,7 @@
 	    <p class="lead smaller"> Go to the address bar of this page, and append <b>/api/github_username/repository_name</b> to it. So if I want the API derived from GitHub's username <i>foo</i> and repository <i>bar</i>, I append <i>/api/foo/bar/</i> to the domain name (<i>/api/foo/bar/api-docs</i> will work too). Now hit enter. Done!</p>
             <p class="lead">
 	      <a href="https://github.com/albertmeronyo/lodapi/" class="btn btn-md btn-block btn-default">Show me an example SPARQL repo</a>
-              <a href="/api-git/albertmeronyo/lodapi/" class="btn btn-md btn-block btn-default">Show me the equivalent API</a>
+              <a href="./api-git/albertmeronyo/lodapi/" class="btn btn-md btn-block btn-default">Show me the equivalent API</a>
             </p>
           </div>
 


### PR DESCRIPTION
This should fix issues when grlc runs behind on a sub-path (and not on the server root path)