### PR TITLE
Path testing

### DIFF
--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -2,6 +2,8 @@ from mock import Mock
 from os import path
 from glob import glob
 
+from grlc.fileLoaders import LocalLoader
+
 base_url = path.join('tests', 'repo')
 def buildEntry(entryName):
     entryName = entryName.replace(base_url, '')
@@ -68,3 +70,5 @@ filesInRepo = [
         u'download_url': u'https://example.org/path/to/fakeFile.rq',
     }
 ]
+
+mockLoader = LocalLoader('./tests/repo/')

--- a/tests/test_gquery.py
+++ b/tests/test_gquery.py
@@ -3,7 +3,8 @@ import six
 import rdflib
 from mock import patch, Mock
 
-from grlc.fileLoaders import LocalLoader
+from tests.mock_data import mockLoader
+
 import grlc.gquery as gquery
 
 from flask import Flask
@@ -12,7 +13,7 @@ from flask import Flask
 class TestGQuery(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.loader = LocalLoader('./tests/repo/')
+        self.loader = mockLoader
         self.app = Flask('unittests')
 
     def test_guess_endpoint(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,15 +2,14 @@ import unittest
 from mock import patch, Mock
 import json
 
-from grlc.fileLoaders import LocalLoader
 import grlc.utils as utils
 
-from tests.mock_data import mock_simpleSparqlResponse
+from tests.mock_data import mock_simpleSparqlResponse, mockLoader
 
 class TestUtils(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.loader = LocalLoader('./tests/repo/')
+        self.loader = mockLoader
 
     @patch('requests.get')
     def test_sparql_transformer(self, mock_get):


### PR DESCRIPTION
Fixes #176 

Paths checked
## Spec generation, front-end
`/api-git/testuser/testrepo`
`/api-git/testuser/testrepo/subdir/<subdir>`
`/api-git/testuser/testrepo/commit/<sha>`
`/api-git/testuser/testrepo/subdir/<subdir>/commit/<sha>`
`/api-local/`
`/api-url/?specUrl=<specUrl>`

## Spec generation, JSON
`/api-git/testuser/testrepo/swagger`
`/api-git/testuser/testrepo/subdir/<subdir>/swagger`
`/api-git/testuser/testrepo/commit/<sha>/swagger`
`/api-git/testuser/testrepo/subdir/<subdir>commit/<sha>/swagger`
`/api-local/swagger`
`/api-url/swagger?specUrl=<specUrl>`

## Callname execution
`/api-git/testuser/testrepo/<query_name>`
`/api-git/testuser/testrepo/subdir/<subdir>/<query_name>`
`/api-git/testuser/testrepo/commit/<sha>/<query_name>`
`/api-git/testuser/testrepo/subdir/<subdir>commit/<sha>/<query_name>`
`/api-local/<query_name>`
`/api-url/<query_name>?specUrl=<specUrl>`

# Notes:
README lists `http://grlc.io/api-git/CLARIAH/grlc-queries/spec/` -- should we change this to be `/swagger`? Should we keep both?

`/<query_name>.<content>` option is not documented anywhere. Should we drop it or document it and add tests for it?
