### PR TITLE
Document parameter mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ grlc is a lightweight server that takes SPARQL queries (stored in a GitHub repos
 For a quick usage tutorial check out our wiki [walkthrough](https://github.com/CLARIAH/grlc/wiki/Quick-tutorial) and [list of features](https://github.com/CLARIAH/grlc/wiki/Features).
 
 ## Usage
-grlc assumes that you have a collection of SPARQL queries as .rq files (like [this](https://github.com/CEDAR-project/Queries)). grlc will create an API operation per such a SPARQL query/.rq file. Your queries can include special [decorators](#decorator-syntax) to add extra functionality to your API.
+grlc assumes that you have a collection of SPARQL queries as .rq files (like [this](https://github.com/CLARIAH/grlc-queries)). grlc will create one API operation for each SPARQL query/.rq file in the collection.
+
+Your queries can add API parameters to each operation by using the [parameter mapping](https://github.com/CLARIAH/grlc/wiki/Parameter-Mapping) syntax. This allows your query to define query variables which will be mapped to API parameters for your API operation ([see here](https://github.com/CLARIAH/grlc-queries/blob/master/enumerate.rq) for an example).
+
+Your queries can include special [decorators](#decorator-syntax) to add extra functionality to your API.
 
 ### Query location
 grlc can load your query collection from different locations: from a GitHub repository (`api-git`), from local storage (`api-local`), and from a specification file (`api-url`). Each type of location has specific features and is accessible via different paths. However all location types produce the same beautiful APIs.
@@ -208,6 +212,7 @@ Check these out:
 - http://grlc.io/api-git/CLARIAH/wp4-queries-hisco
 - http://grlc.io/api-git/albertmeronyo/lodapi
 - http://grlc.io/api-git/albertmeronyo/lsq-api
+- https://grlc.io/api-git/CEDAR-project/Queries
 
 You'll find the sources of these and many more in [GitHub](https://github.com/search?o=desc&q=endpoint+summary+language%3ASPARQL&s=indexed&type=Code&utf8=%E2%9C%93)
 


### PR DESCRIPTION
Parameter mapping was not really documented on the README.

This fixes #279 -- thanks @CunliangGeng for spotting this!