### PR TITLE
Warning prefixes

### DIFF
--- a/doc/notebooks/GrlcFromNotebook.ipynb
+++ b/doc/notebooks/GrlcFromNotebook.ipynb
@@ -12,111 +12,84 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:rdflib:RDFLib Version: 4.2.1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "import json\n",
     "import pandas as pd\n",
     "from io import StringIO\n",
     "\n",
     "import grlc\n",
     "import grlc.utils as utils\n",
-    "import grlc.swagger as swagger\n"
+    "import grlc.swagger as swagger"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can load the grlc specification for a github repository. For example, my github username is `c-martinez` and my SPARQL queries are on `grlc-queries` [repo](https://github.com/c-martinez/grlc-queries). "
+    "We can load the grlc specification for a github repository. For example, the grlc test query repository https://github.com/CLARIAH/grlc-queries."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:grlc.gquery:Decorator guessed endpoint: http://dbpedia.org/sparql\n",
-      "INFO:grlc.gquery:Decorator guessed endpoint: http://dbpedia.org/sparql\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "user = 'c-martinez'\n",
+    "user = 'CLARIAH'\n",
     "repo = 'grlc-queries'\n",
-    "spec = swagger.build_spec(user, repo)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['call_name', 'params', 'description', 'tags', 'item_properties', 'query', 'method', 'summary']\n"
-     ]
-    }
-   ],
-   "source": [
-    "print spec[0].keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "PREFIX dbo: <http://dbpedia.org/ontology/>\n",
-      "\n",
-      "SELECT ?country_name ?capital_name ?population\n",
-      "WHERE {\n",
-      "  ?country rdf:type dbo:Country .\n",
-      "  ?country dbo:capital ?capital .\n",
-      "\n",
-      "  ?capital rdfs:label  ?capital_name .\n",
-      "  ?country rdfs:label  ?country_name .\n",
-      "  ?country dbo:populationTotal ?population .\n",
-      "\n",
-      "  FILTER (lang(?capital_name) = 'en')\n",
-      "  FILTER (lang(?country_name) = 'en')\n",
-      "  FILTER NOT EXISTS { ?country dbo:dissolutionYear ?yearEnd }\n",
-      "  FILTER (?population > 500000)\n",
-      "} LIMIT 1000\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "print spec[0]['query']"
+    "spec, warning = swagger.build_spec(user, repo)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use `dispatch_query` functions to load data from a specific query (`dbpediaCapitals` in this case). For this example, we are loading data in `text/csv` format.\n",
-    "\n",
-    "**NOTE:** `dbpediaCapitals` query loads data from dbpedia.org -- the endpoint is specified via the endpoint decorator on the query file itself."
+    "We can have a look at one item of the returned specification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"call_name\": \"/description\",\n",
+      "  \"method\": \"get\",\n",
+      "  \"tags\": [],\n",
+      "  \"summary\": \"\",\n",
+      "  \"description\": \"Extended description of my query/operation. This can be a more extensive than the summary and in can span multiple lines.\\nDescriptions support (to some extent) [CommonMark](https://commonmark.org/help/).\",\n",
+      "  \"params\": [\n",
+      "    {\n",
+      "      \"name\": \"endpoint\",\n",
+      "      \"type\": \"string\",\n",
+      "      \"in\": \"query\",\n",
+      "      \"description\": \"Alternative endpoint for SPARQL query\",\n",
+      "      \"default\": \"https://dbpedia.org/sparql\"\n",
+      "    }\n",
+      "  ],\n",
+      "  \"item_properties\": null,\n",
+      "  \"query\": \"\\nPREFIX dbo: <http://dbpedia.org/ontology/>\\nPREFIX schema: <http://schema.org/>\\nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\\n\\nSELECT ?band ?album ?genre WHERE {\\n  ?band rdf:type dbo:Band .\\n  ?album rdf:type schema:MusicAlbum .\\n  ?band dbo:genre ?genre .\\n  ?album dbo:artist ?band .\\n} LIMIT 100\\n\",\n",
+      "  \"original_query\": \"#+ description: Extended description of my query/operation.\\n#+     This can be a more extensive than the summary and in can span\\n#+     multiple lines.\\n#+\\n#+     Descriptions support (to some extent) [CommonMark](https://commonmark.org/help/).\\n\\nPREFIX dbo: <http://dbpedia.org/ontology/>\\nPREFIX schema: <http://schema.org/>\\nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\\n\\nSELECT ?band ?album ?genre WHERE {\\n  ?band rdf:type dbo:Band .\\n  ?album rdf:type schema:MusicAlbum .\\n  ?band dbo:genre ?genre .\\n  ?album dbo:artist ?band .\\n} LIMIT 100\\n\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(json.dumps(spec[0], indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This specification item will execute the following SPARQL query:"
    ]
   },
   {
@@ -125,15 +98,77 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:grlc.gquery:Decorator guessed endpoint: http://dbpedia.org/sparql\n"
+      "\n",
+      "PREFIX dbo: <http://dbpedia.org/ontology/>\n",
+      "PREFIX schema: <http://schema.org/>\n",
+      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "\n",
+      "SELECT ?band ?album ?genre WHERE {\n",
+      "  ?band rdf:type dbo:Band .\n",
+      "  ?album rdf:type schema:MusicAlbum .\n",
+      "  ?band dbo:genre ?genre .\n",
+      "  ?album dbo:artist ?band .\n",
+      "} LIMIT 100\n",
+      "\n"
      ]
     }
    ],
    "source": [
-    "query_name = 'dbpediaCapitals'\n",
+    "print(spec[0]['query'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can execute this query by calling the API point in our generated API:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/description\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(spec[0]['call_name'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use `dispatch_query` functions to load data from a specific query (`description` in this case). For this example, we are loading data in `text/csv` format.\n",
+    "\n",
+    "**NOTE:** `description` query loads data from dbpedia.org -- the endpoint is specified in the repository `endpoint.txt` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requesting query at https://raw.githubusercontent.com/CLARIAH/grlc-queries/master/description.rq\n",
+      "Requesting query at https://raw.githubusercontent.com/CLARIAH/grlc-queries/master/endpoint.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "query_name = 'description'\n",
     "acceptHeader = 'text/csv'\n",
     "\n",
     "data, code, headers = utils.dispatch_query(user, repo, query_name, acceptHeader=acceptHeader)"
@@ -148,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -172,91 +207,115 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>country_name</th>\n",
-       "      <th>capital_name</th>\n",
-       "      <th>population</th>\n",
+       "      <th>band</th>\n",
+       "      <th>album</th>\n",
+       "      <th>genre</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>Albania</td>\n",
-       "      <td>Tirana</td>\n",
-       "      <td>2886026</td>\n",
+       "      <td>http://dbpedia.org/resource/Asia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Axioms_(album)</td>\n",
+       "      <td>http://dbpedia.org/resource/Art_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>Algeria</td>\n",
-       "      <td>Algiers</td>\n",
-       "      <td>40400000</td>\n",
+       "      <td>http://dbpedia.org/resource/Asia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Axioms_(album)</td>\n",
+       "      <td>http://dbpedia.org/resource/Progressive_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>Greece</td>\n",
-       "      <td>Athens</td>\n",
-       "      <td>10955000</td>\n",
+       "      <td>http://dbpedia.org/resource/Asia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Axioms_(album)</td>\n",
+       "      <td>http://dbpedia.org/resource/Album-oriented_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>Azerbaijan</td>\n",
-       "      <td>Baku</td>\n",
-       "      <td>9754830</td>\n",
+       "      <td>http://dbpedia.org/resource/Asia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Axioms_(album)</td>\n",
+       "      <td>http://dbpedia.org/resource/Arena_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>Germany</td>\n",
-       "      <td>Berlin</td>\n",
-       "      <td>82175700</td>\n",
+       "      <td>http://dbpedia.org/resource/Bauhaus_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Swing_the_Heartach...</td>\n",
+       "      <td>http://dbpedia.org/resource/Gothic_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>Brazil</td>\n",
-       "      <td>Brasília</td>\n",
-       "      <td>206440850</td>\n",
+       "      <td>http://dbpedia.org/resource/Bauhaus_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Swing_the_Heartach...</td>\n",
+       "      <td>http://dbpedia.org/resource/Post-punk</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>European Union</td>\n",
-       "      <td>Brussels</td>\n",
-       "      <td>510056011</td>\n",
+       "      <td>http://dbpedia.org/resource/Catatonia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Paper_Scissors_Sto...</td>\n",
+       "      <td>http://dbpedia.org/resource/Alternative_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>Syria</td>\n",
-       "      <td>Damascus</td>\n",
-       "      <td>17064854</td>\n",
+       "      <td>http://dbpedia.org/resource/Catatonia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Paper_Scissors_Sto...</td>\n",
+       "      <td>http://dbpedia.org/resource/Indie_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>Finland</td>\n",
-       "      <td>Helsinki</td>\n",
-       "      <td>5488543</td>\n",
+       "      <td>http://dbpedia.org/resource/Siouxsie_and_the_B...</td>\n",
+       "      <td>http://dbpedia.org/resource/Tinderbox_(Siouxsi...</td>\n",
+       "      <td>http://dbpedia.org/resource/Gothic_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>Indonesia</td>\n",
-       "      <td>Jakarta</td>\n",
-       "      <td>255461700</td>\n",
+       "      <td>http://dbpedia.org/resource/Siouxsie_and_the_B...</td>\n",
+       "      <td>http://dbpedia.org/resource/Tinderbox_(Siouxsi...</td>\n",
+       "      <td>http://dbpedia.org/resource/New_wave_music</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "     country_name capital_name  population\n",
-       "0         Albania       Tirana     2886026\n",
-       "1         Algeria      Algiers    40400000\n",
-       "2          Greece       Athens    10955000\n",
-       "3      Azerbaijan         Baku     9754830\n",
-       "4         Germany       Berlin    82175700\n",
-       "5          Brazil     Brasília   206440850\n",
-       "6  European Union     Brussels   510056011\n",
-       "7           Syria     Damascus    17064854\n",
-       "8         Finland     Helsinki     5488543\n",
-       "9       Indonesia      Jakarta   255461700"
+       "                                                band  \\\n",
+       "0            http://dbpedia.org/resource/Asia_(band)   \n",
+       "1            http://dbpedia.org/resource/Asia_(band)   \n",
+       "2            http://dbpedia.org/resource/Asia_(band)   \n",
+       "3            http://dbpedia.org/resource/Asia_(band)   \n",
+       "4         http://dbpedia.org/resource/Bauhaus_(band)   \n",
+       "5         http://dbpedia.org/resource/Bauhaus_(band)   \n",
+       "6       http://dbpedia.org/resource/Catatonia_(band)   \n",
+       "7       http://dbpedia.org/resource/Catatonia_(band)   \n",
+       "8  http://dbpedia.org/resource/Siouxsie_and_the_B...   \n",
+       "9  http://dbpedia.org/resource/Siouxsie_and_the_B...   \n",
+       "\n",
+       "                                               album  \\\n",
+       "0         http://dbpedia.org/resource/Axioms_(album)   \n",
+       "1         http://dbpedia.org/resource/Axioms_(album)   \n",
+       "2         http://dbpedia.org/resource/Axioms_(album)   \n",
+       "3         http://dbpedia.org/resource/Axioms_(album)   \n",
+       "4  http://dbpedia.org/resource/Swing_the_Heartach...   \n",
+       "5  http://dbpedia.org/resource/Swing_the_Heartach...   \n",
+       "6  http://dbpedia.org/resource/Paper_Scissors_Sto...   \n",
+       "7  http://dbpedia.org/resource/Paper_Scissors_Sto...   \n",
+       "8  http://dbpedia.org/resource/Tinderbox_(Siouxsi...   \n",
+       "9  http://dbpedia.org/resource/Tinderbox_(Siouxsi...   \n",
+       "\n",
+       "                                             genre  \n",
+       "0             http://dbpedia.org/resource/Art_rock  \n",
+       "1     http://dbpedia.org/resource/Progressive_rock  \n",
+       "2  http://dbpedia.org/resource/Album-oriented_rock  \n",
+       "3           http://dbpedia.org/resource/Arena_rock  \n",
+       "4          http://dbpedia.org/resource/Gothic_rock  \n",
+       "5            http://dbpedia.org/resource/Post-punk  \n",
+       "6     http://dbpedia.org/resource/Alternative_rock  \n",
+       "7           http://dbpedia.org/resource/Indie_rock  \n",
+       "8          http://dbpedia.org/resource/Gothic_rock  \n",
+       "9       http://dbpedia.org/resource/New_wave_music  "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -277,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,17 +345,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
     "headers = {'accept': 'text/csv'}\n",
-    "resp = requests.get(\"http://grlc.io/api/c-martinez/grlc-queries/dbpediaCapitals\", headers=headers)"
+    "resp = requests.get(\"http://grlc.io/api-git/CLARIAH/grlc-queries/description\", headers=headers)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -320,91 +379,115 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>country_name</th>\n",
-       "      <th>capital_name</th>\n",
-       "      <th>population</th>\n",
+       "      <th>band</th>\n",
+       "      <th>album</th>\n",
+       "      <th>genre</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>Albania</td>\n",
-       "      <td>Tirana</td>\n",
-       "      <td>2886026</td>\n",
+       "      <td>http://dbpedia.org/resource/Asia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Axioms_(album)</td>\n",
+       "      <td>http://dbpedia.org/resource/Art_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>Algeria</td>\n",
-       "      <td>Algiers</td>\n",
-       "      <td>40400000</td>\n",
+       "      <td>http://dbpedia.org/resource/Asia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Axioms_(album)</td>\n",
+       "      <td>http://dbpedia.org/resource/Progressive_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>Greece</td>\n",
-       "      <td>Athens</td>\n",
-       "      <td>10955000</td>\n",
+       "      <td>http://dbpedia.org/resource/Asia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Axioms_(album)</td>\n",
+       "      <td>http://dbpedia.org/resource/Album-oriented_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>Azerbaijan</td>\n",
-       "      <td>Baku</td>\n",
-       "      <td>9754830</td>\n",
+       "      <td>http://dbpedia.org/resource/Asia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Axioms_(album)</td>\n",
+       "      <td>http://dbpedia.org/resource/Arena_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>Germany</td>\n",
-       "      <td>Berlin</td>\n",
-       "      <td>82175700</td>\n",
+       "      <td>http://dbpedia.org/resource/Bauhaus_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Swing_the_Heartach...</td>\n",
+       "      <td>http://dbpedia.org/resource/Gothic_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>Brazil</td>\n",
-       "      <td>Brasília</td>\n",
-       "      <td>206440850</td>\n",
+       "      <td>http://dbpedia.org/resource/Bauhaus_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Swing_the_Heartach...</td>\n",
+       "      <td>http://dbpedia.org/resource/Post-punk</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>European Union</td>\n",
-       "      <td>Brussels</td>\n",
-       "      <td>510056011</td>\n",
+       "      <td>http://dbpedia.org/resource/Catatonia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Paper_Scissors_Sto...</td>\n",
+       "      <td>http://dbpedia.org/resource/Alternative_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>Syria</td>\n",
-       "      <td>Damascus</td>\n",
-       "      <td>17064854</td>\n",
+       "      <td>http://dbpedia.org/resource/Catatonia_(band)</td>\n",
+       "      <td>http://dbpedia.org/resource/Paper_Scissors_Sto...</td>\n",
+       "      <td>http://dbpedia.org/resource/Indie_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>Finland</td>\n",
-       "      <td>Helsinki</td>\n",
-       "      <td>5488543</td>\n",
+       "      <td>http://dbpedia.org/resource/Siouxsie_and_the_B...</td>\n",
+       "      <td>http://dbpedia.org/resource/Tinderbox_(Siouxsi...</td>\n",
+       "      <td>http://dbpedia.org/resource/Gothic_rock</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>Indonesia</td>\n",
-       "      <td>Jakarta</td>\n",
-       "      <td>255461700</td>\n",
+       "      <td>http://dbpedia.org/resource/Siouxsie_and_the_B...</td>\n",
+       "      <td>http://dbpedia.org/resource/Tinderbox_(Siouxsi...</td>\n",
+       "      <td>http://dbpedia.org/resource/New_wave_music</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "     country_name capital_name  population\n",
-       "0         Albania       Tirana     2886026\n",
-       "1         Algeria      Algiers    40400000\n",
-       "2          Greece       Athens    10955000\n",
-       "3      Azerbaijan         Baku     9754830\n",
-       "4         Germany       Berlin    82175700\n",
-       "5          Brazil     Brasília   206440850\n",
-       "6  European Union     Brussels   510056011\n",
-       "7           Syria     Damascus    17064854\n",
-       "8         Finland     Helsinki     5488543\n",
-       "9       Indonesia      Jakarta   255461700"
+       "                                                band  \\\n",
+       "0            http://dbpedia.org/resource/Asia_(band)   \n",
+       "1            http://dbpedia.org/resource/Asia_(band)   \n",
+       "2            http://dbpedia.org/resource/Asia_(band)   \n",
+       "3            http://dbpedia.org/resource/Asia_(band)   \n",
+       "4         http://dbpedia.org/resource/Bauhaus_(band)   \n",
+       "5         http://dbpedia.org/resource/Bauhaus_(band)   \n",
+       "6       http://dbpedia.org/resource/Catatonia_(band)   \n",
+       "7       http://dbpedia.org/resource/Catatonia_(band)   \n",
+       "8  http://dbpedia.org/resource/Siouxsie_and_the_B...   \n",
+       "9  http://dbpedia.org/resource/Siouxsie_and_the_B...   \n",
+       "\n",
+       "                                               album  \\\n",
+       "0         http://dbpedia.org/resource/Axioms_(album)   \n",
+       "1         http://dbpedia.org/resource/Axioms_(album)   \n",
+       "2         http://dbpedia.org/resource/Axioms_(album)   \n",
+       "3         http://dbpedia.org/resource/Axioms_(album)   \n",
+       "4  http://dbpedia.org/resource/Swing_the_Heartach...   \n",
+       "5  http://dbpedia.org/resource/Swing_the_Heartach...   \n",
+       "6  http://dbpedia.org/resource/Paper_Scissors_Sto...   \n",
+       "7  http://dbpedia.org/resource/Paper_Scissors_Sto...   \n",
+       "8  http://dbpedia.org/resource/Tinderbox_(Siouxsi...   \n",
+       "9  http://dbpedia.org/resource/Tinderbox_(Siouxsi...   \n",
+       "\n",
+       "                                             genre  \n",
+       "0             http://dbpedia.org/resource/Art_rock  \n",
+       "1     http://dbpedia.org/resource/Progressive_rock  \n",
+       "2  http://dbpedia.org/resource/Album-oriented_rock  \n",
+       "3           http://dbpedia.org/resource/Arena_rock  \n",
+       "4          http://dbpedia.org/resource/Gothic_rock  \n",
+       "5            http://dbpedia.org/resource/Post-punk  \n",
+       "6     http://dbpedia.org/resource/Alternative_rock  \n",
+       "7           http://dbpedia.org/resource/Indie_rock  \n",
+       "8          http://dbpedia.org/resource/Gothic_rock  \n",
+       "9       http://dbpedia.org/resource/New_wave_music  "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -417,21 +500,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15rc1"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/src/utils.py
+++ b/src/utils.py
@@ -36,7 +36,8 @@ def build_spec(user, repo, subdir=None, sha=None, prov=None, extraMetadata=[]):
     Deprecated."""
     glogger.warning("grlc.utils.build_spec is deprecated and will " \
                     "be removed in the future. Use grlc.swagger.build_spec instead.")
-    return swagger.build_spec(user, repo, subdir, sha, prov, extraMetadata)
+    items, _ = swagger.build_spec(user, repo, subdir, sha, prov, extraMetadata)
+    return items
 
 
 def build_swagger_spec(user, repo, subdir, spec_url, sha, serverName):
@@ -69,9 +70,17 @@ def build_swagger_spec(user, repo, subdir, spec_url, sha, serverName):
     swag['basePath'] = basePath
 
     # TODO: can we pass loader to build_spec ? --> Ideally yes!
-    spec = swagger.build_spec(user, repo, subdir, spec_url, sha, prov_g)
+    spec, warnings = swagger.build_spec(user, repo, subdir, spec_url, sha, prov_g)
+    # Use items to build API paths
     for item in spec:
         swag['paths'][item['call_name']] = swagger.get_path_for_item(item)
+
+     # TODO: Add bootstrap style to top level HTML
+    # Without a better place to display warnings, we can make them part of the description.
+    if 'description' not in swag['info']:
+        swag['info']['description'] = ''
+    for warn in warnings:
+        swag['info']['description'] += swagger.get_warning_div(warn)
 
     if prov_g:
         prov_g.end_prov_graph()

--- a/tests/test_grlc.py
+++ b/tests/test_grlc.py
@@ -23,7 +23,7 @@ class TestGrlcLib(unittest.TestCase):
 
         user = 'testuser'
         repo = 'testrepo'
-        spec = swagger.build_spec(user=user, repo=repo)
+        spec, warning = swagger.build_spec(user=user, repo=repo)
 
         self.assertEqual(len(spec), len(filesInRepo))
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -19,7 +19,7 @@ class TestSwagger(unittest.TestCase):
 
         user = 'testuser'
         repo = 'testrepo'
-        spec = build_spec(user, repo)
+        spec, warnings = build_spec(user, repo)
 
         self.assertEqual(len(spec), len(filesInRepo))
 


### PR DESCRIPTION
This PR adds the following functionality:

When grlc is not able to generate an API endpoint from a `*.rq` file, a warning is generated. These warnings are then displayed in the swagger API.

This fixes #168 