### PR TITLE
Control results format by adding a file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ Syntax:
 
 Example [query](https://github.com/CLARIAH/grlc-queries/blob/master/tags.rq) and the equivalent [API operation](http://grlc.io/api-git/CLARIAH/grlc-queries/#/group1/get_tags).
 
+### `defaults`
+Set the default value in the swagger-ui for a specific parameter in the query.
+
+Syntax:
+```
+#+ defaults:
+#+   - param_name: default_value
+```
+
+Example [query](https://github.com/CLARIAH/grlc-queries/blob/master/defaults.rq) and the equivalent [API operation](http://grlc.io/api-git/CLARIAH/grlc-queries/#/default/get_defaults).
+
 ### `enumerate`
 Indicates which parameters of your query/operation should get enumerations (and get dropdown menus in the swagger-ui) using the given values from the SPARQL endpoint. The values for each enumeration variable can also be specified into the query decorators to save endpoint requests and speed up the API generation.
 

--- a/src/server.py
+++ b/src/server.py
@@ -89,10 +89,12 @@ def swagger_spec_local():
 
 # Callname execution
 @app.route('/api-local/<query_name>', methods=['GET', 'POST'])
+@app.route('/api-local/<query_name>.<content>', methods=['GET', 'POST'])
 @app.route('/api/local/local/<query_name>', methods=['GET', 'POST'], strict_slashes=False)  # backward compatibility route
-def query_local(query_name):
+@app.route('/api/local/local/<query_name>.<content>', methods=['GET', 'POST'], strict_slashes=False)  # backward compatibility route
+def query_local(query_name, content=None):
     """SPARQL query execution for local routes."""
-    return query(user=None, repo=None, query_name=query_name)
+    return query(user=None, repo=None, query_name=query_name, content=content)
 
 ################################
 ### Routes for URL HTTP APIs ###
@@ -118,11 +120,12 @@ def swagger_spec_param():
 
 # Callname execution
 @app.route('/api-url/<query_name>', methods=['GET', 'POST'])
-def query_param(query_name):
+@app.route('/api-url/<query_name>.<content>', methods=['GET', 'POST'])
+def query_param(query_name, content=None):
     """SPARQL query execution for specifications loaded via http."""
     spec_url = request.args['specUrl']
     glogger.debug("Spec URL: {}".format(spec_url))
-    return query(user=None, repo=None, query_name=query_name, spec_url=spec_url)
+    return query(user=None, repo=None, query_name=query_name, spec_url=spec_url, content=content)
 
 ##############################
 ### Routes for GitHub APIs ###


### PR DESCRIPTION
This functionality was already implemented for `/api-git` paths, but not for `/api-local` and `/api-url`. This PR adds this extra functionality. 

Fixes #304