### PR TITLE
Remove 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 cache: pip
-python: 3.5
+python: 3.6
 
 before_install:
   - source .travis/before_install.sh


### PR DESCRIPTION
Actually were only using 3.5 functionality for testing.

Fixes #303