### PR TITLE
Handle errors raised by missing prefix

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -124,7 +124,11 @@ def dispatchSPARQLQuery(raw_sparql_query, loader, requestArgs, acceptHeader, con
     glogger.debug("Sending query to SPARQL endpoint: {}".format(endpoint))
     glogger.debug("=====================================================")
 
-    query_metadata = gquery.get_metadata(raw_sparql_query, endpoint)
+    try:
+        query_metadata = gquery.get_metadata(raw_sparql_query, endpoint)
+    except Exception as e:
+        # extracting metadata
+        return { 'error': str(e) }, 400, {}
 
     acceptHeader = 'application/json' if isinstance(raw_sparql_query, dict) else acceptHeader
     pagination = query_metadata['pagination'] if 'pagination' in query_metadata else ""


### PR DESCRIPTION
When a prefix is missing on the query, an internal server error is raised. This PR manages this more gracefully.

This PR and #315 both address issues raised when executing a query. Perhaps we should merge them and have a more elegant way to handle query execution issues.