### PR TITLE
Fix query display in summary

### DIFF
--- a/src/swagger.py
+++ b/src/swagger.py
@@ -82,7 +82,7 @@ def get_path_for_item(item):
         query = "\n" + json.dumps(query, indent=2) + "\n"
 
     description = item['description']
-    description += '\n\n```{}```'.format(query)
+    description += '\n\n```\n{}\n```'.format(query)
     description += '\n\nSPARQL transformation:\n```json\n{}```'.format(
         item['transform']) if 'transform' in item else ''
 


### PR DESCRIPTION
For queries displayed in the detail of swagger-ui, the first line of the query is being removed (commented out). 

For example this query:

```
#+ summary: Returns the bands
#+ endpoint: http://dbpedia.org/sparql

PREFIX dbo: <http://dbpedia.org/ontology/>

SELECT ?band WHERE {
  ?band a dbo:Band .
  ?band dbo:genre ?__genre_iri .
} 
LIMIT 30
```

Is displayed like this (`summary` is missing):
![image](https://user-images.githubusercontent.com/7782231/107271213-34279480-6a4c-11eb-9358-5d2548c445b2.png)

This PR fixes this issue.