### PR TITLE
 Bump pyyaml from 4.2b1 to 5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ keepalive==0.5
 MarkupSafe==0.23
 pyaml==18.11.0
 pyparsing==2.0.7
-PyYAML==4.2b1
+PyYAML==5.4
 rdflib==4.2.2
 rdflib-jsonld==0.4.0
 requests==2.20.0


### PR DESCRIPTION
Manually implementing dependency updates from https://github.com/CLARIAH/grlc/pull/323