### PR TITLE
Preparing for 1.3.6 release

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -19,5 +19,6 @@ if [[ $TRAVIS_BUILD_STAGE_NAME == 'Deploy' ]]; then
 fi
 
 pip install --upgrade pip
+pip install docutils==0.17.1
 pip install .
 pip install -r requirements-test.txt

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -31,5 +31,5 @@
     },
     "publication_date": "2017-11-22",
     "title": "grlc",
-    "version": "1.3.4"
+    "version": "1.3.6"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,4 +32,4 @@ keywords:
   - "linked-data"
   - "semantic-web"
   - "linked-data-api"
-version: "1.3.4"
+version: "1.3.6"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,5 @@ This is a list of all people who have contributed to grlc. Big thanks to everyon
 [mwigham](https://github.com/mwigham)  
 [steltenpower](https://github.com/steltenpower)  
 [jspaaks](https://github.com/jspaaks)  
+[ecow](https://github.com/ecow)
+[rapw3k](https://github.com/rapw3k)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 docopt==0.6.2
+docutils==0.17.1
 Flask==1.0.2
 Flask-Cors==3.0.6
 gevent==1.4.0


### PR DESCRIPTION
This release includes:
 - Update documentation & contributing guidelines
 - Update requirements (docutils)
 - Add format control via extension (thanks @ecow for reporting)
 - Remove 3.5 support
 - Remove support for `/spec` in favour of `/swagger`
 - Restrict transform decorator to application/json (thanks @ecow for reporting)
 - Catching exception connecting to SPARQL endpoint
 - Handle errors raised by missing prefix
 - Fix query display in summary
 - Upgrade SPARQL transformer to support list objects (thanks @rapw3k for suggesting this feature and @pasqLisena for implementing it)
