### PR TITLE
Pip installable up to python 3.9

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,7 +6,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [ 3.7, 3.8, 3.9]
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.6
     steps:
     - uses: actions/checkout@master
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,12 +21,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
         pip install -r requirements-test.txt
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 src/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 src/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest ./tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@master
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,10 @@ docopt==0.6.2
 docutils==0.17.1
 Flask==1.0.2
 Flask-Cors==3.0.9
-gevent==1.4.0
-greenlet==0.4.15
+gevent==1.4.0; python_version <= '3.8'
+gevent==22.10.2; python_version > '3.8'
+greenlet==0.4.15; python_version <= '3.8'
+greenlet==2.0.0; python_version > '3.8'
 html5lib==1.0.1
 isodate==0.5.4; python_version <= '3.6'
 isodate==0.6.1; python_version > '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,22 +5,26 @@ Flask-Cors==3.0.9
 gevent==1.4.0
 greenlet==0.4.15
 html5lib==1.0.1
-isodate==0.5.4
+isodate==0.5.4; python_version <= '3.6'
+isodate==0.6.1; python_version > '3.6'
 itsdangerous==1.1.0
-keepalive==0.5
+keepalive==0.5; python_version <= '3.6'
 MarkupSafe==0.23
 pyaml==18.11.0
 pyparsing==2.0.7
 PyYAML==5.4
-rdflib==4.2.2
-rdflib-jsonld==0.4.0
+rdflib==4.2.2; python_version <= '3.6'
+rdflib==5.0.0; python_version > '3.6'
+rdflib-jsonld==0.4.0; python_version <= '3.6'
+rdflib-jsonld==0.6.2; python_version > '3.6'
 requests==2.20.0
 six==1.12.0
 simplejson==3.16.0
 setuptools>=38.6.0
 SPARQLTransformer==2.1.1
 SPARQLWrapper==1.8.2
-werkzeug>=0.16.0
-PyGithub==1.43.5
+werkzeug==0.16.0
+PyGithub==1.43.5; python_version <= '3.6'
+PyGithub==1.57; python_version > '3.6'
 gunicorn==19.6.0; sys_platform!="win32"
 waitress>=1.4.2; sys_platform=="win32"


### PR DESCRIPTION
Tested for Pythons 3.6.15 | 3.7.16 | 3.8.16 | 3.9.16 as follows:

```bash
virtualenv py3X --python python3X
source py3X/bin/activate
pip install .
pip install -r requirements-test.txt
pytest tests/
deactivate
```
(where the X is the python version 6, 7, 8 or 9)