### PR TITLE
Manually incorporatig Gitlab support

### DIFF
--- a/config.default.ini
+++ b/config.default.ini
@@ -12,4 +12,7 @@ server_name = grlc.io
 user = none
 password = none
 # Logging level
-debug = False
+debug = True
+
+[api_gitlab]
+gitlab_url=https://gitlab

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,11 @@ keepalive==0.5
 MarkupSafe==0.23
 pyaml==18.11.0
 pyparsing==2.0.7
+python-gitlab==2.10.1
 PyYAML==5.4
 rdflib==4.2.2
 rdflib-jsonld==0.4.0
-requests==2.20.0
+requests==2.27.1
 six==1.12.0
 simplejson==3.16.0
 setuptools>=38.6.0

--- a/src/server.py
+++ b/src/server.py
@@ -164,7 +164,7 @@ def api_docs_git(user, repo, subdir=None, sha=None):
 @app.route('/api-git/<user>/<repo>/<path:subdir>/commit/<sha>/swagger')  # backward compatibility route
 def swagger_spec_git(user, repo, subdir=None, sha=None):
     """Swagger spec for specifications loaded from a Github repo."""
-    return swagger_spec(user, repo, subdir=subdir, spec_url=None, sha=sha, content=None, git_type="github")
+    return swagger_spec(user, repo, subdir=subdir, spec_url=None, sha=sha, content=None, git_type=static.TYPE_GITHUB)
 
 # Callname execution
 @app.route('/api-git/<user>/<repo>/<query_name>', methods=['GET', 'POST'])
@@ -185,7 +185,7 @@ def swagger_spec_git(user, repo, subdir=None, sha=None):
 @app.route('/api/<user>/<repo>/<path:subdir>/commit/<sha>/<query_name>.<content>', methods=['GET', 'POST'])  # backward compatibility route
 def query_git(user, repo, query_name, subdir=None, sha=None, content=None):
     """SPARQL query execution for specifications loaded from a Github repo."""
-    return query(user, repo, query_name, subdir=subdir, sha=sha, content=content, git_type="github")
+    return query(user, repo, query_name, subdir=subdir, sha=sha, content=content, git_type=static.TYPE_GITHUB)
 
 
 
@@ -220,7 +220,7 @@ def api_docs_gitlab(user, repo, subdir=None, sha=None, branch='main'):
 def swagger_spec_gitlab(user, repo, subdir=None, sha=None, branch='main'):
     """Swagger spec for specifications loaded from a Github repo."""
     glogger.debug("Entry in function: __main__.swagger_spec_gitlab")
-    return swagger_spec(user, repo, subdir=subdir, spec_url=None, sha=sha, content=None, git_type="gitlab", branch=branch)
+    return swagger_spec(user, repo, subdir=subdir, spec_url=None, sha=sha, content=None, git_type=static.TYPE_GITLAB, branch=branch)
 
 # Callname execution
 @app.route('/api-gitlab/<user>/<repo>/query/<query_name>', methods=['GET', 'POST'])
@@ -236,7 +236,7 @@ def swagger_spec_gitlab(user, repo, subdir=None, sha=None, branch='main'):
 def query_gitlab(user, repo, query_name, subdir=None, sha=None, content=None, branch='main'):
     """SPARQL query execution for specifications loaded from a Github repo."""
     glogger.debug("Entry in function: __main__.query_gitlab")
-    return query(user, repo, query_name, subdir=subdir, sha=sha, content=content, git_type="gitlab", branch=branch)
+    return query(user, repo, query_name, subdir=subdir, sha=sha, content=content, git_type=static.TYPE_GITLAB, branch=branch)
 
 
 

--- a/src/static.py
+++ b/src/static.py
@@ -35,12 +35,14 @@ config_fallbacks = {
     'password': '',
     'server_name': '',
     'local_sparql_dir': '',
-    'debug': 'False'
+    'debug': 'False',
+    'gitlab_url': 'https://gitlab'
 }
 config = ConfigParser(config_fallbacks)
 config.add_section('auth')
 config.add_section('defaults')
 config.add_section('local')
+config.add_section('api_gitlab')
 config_filename = os.path.join(os.getcwd(), 'config.ini')
 print('Reading config file: ', config_filename)
 config.read(config_filename)
@@ -53,6 +55,9 @@ DEFAULT_ENDPOINT_PASSWORD = config.get('defaults', 'password')
 
 # Local folder where queries are loaded from
 LOCAL_SPARQL_DIR = config.get('local', 'local_sparql_dir')
+
+# api_gitlab
+GITLAB_URL = config.get('api_gitlab', 'gitlab_url')
 
 # server name, used by the Flask app and in the swagger spec
 SERVER_NAME = config.get('defaults', 'server_name')

--- a/src/static.py
+++ b/src/static.py
@@ -22,6 +22,10 @@ mimetypes = {
 GITHUB_RAW_BASE_URL = 'https://raw.githubusercontent.com/'
 GITHUB_API_BASE_URL = 'https://api.github.com/repos/'
 
+# Git types
+TYPE_GITHUB = "github"
+TYPE_GITLAB = "gitlab"
+
 # Cache control
 # CACHE_CONTROL_POLICY = 'public, max-age=60'
 # With the new hash retrieveal and redirect caching becomes obsolete

--- a/src/swagger.py
+++ b/src/swagger.py
@@ -2,7 +2,7 @@ import json
 import grlc.utils
 import grlc.gquery as gquery
 import grlc.pagination as pageUtils
-from grlc.fileLoaders import GithubLoader, LocalLoader, URLLoader
+from grlc.fileLoaders import GithubLoader, LocalLoader, URLLoader, GitlabLoader
 
 import traceback
 import grlc.glogging as glogging
@@ -62,6 +62,11 @@ def get_repo_info(loader, sha, prov_g):
         basePath = '/api-git/' + user_repo + '/'
         basePath += ('subdir/' + loader.subdir + '/') if loader.subdir else ''
         basePath += ('commit/' + sha + '/') if sha else ''
+    if type(loader) is GitlabLoader:
+        basePath = '/api-gitlab/' + user_repo + '/query/' 
+        basePath += ('branch/' + loader.branch + '/') if loader.branch else ''
+        basePath += ('subdir/' + loader.subdir.strip('/') + '/') if loader.subdir else ''
+        basePath += ('commit/' + sha + '/') if sha else ''
     elif type(loader) is LocalLoader:
         basePath = '/api-local/'
     elif type(loader) is URLLoader:
@@ -117,9 +122,9 @@ def get_path_for_item(item):
     return item_path
 
 
-def build_spec(user, repo, subdir=None, query_url=None, sha=None, prov=None, extraMetadata=[]):
+def build_spec(user, repo, subdir=None, query_url=None, sha=None, prov=None, extraMetadata=[], git_type=None, branch='main'):
     """Build grlc specification for the given github user / repo."""
-    loader = grlc.utils.getLoader(user, repo, subdir, query_url, sha=sha, prov=prov)
+    loader = grlc.utils.getLoader(user, repo, subdir, query_url, sha=sha, prov=prov, git_type=git_type, branch=branch)
 
     files = loader.fetchFiles()
     raw_repo_uri = loader.getRawRepoUri()

--- a/src/utils.py
+++ b/src/utils.py
@@ -26,7 +26,7 @@ def getLoader(user, repo, subdir=None, spec_url=None, sha=None, prov=None, git_t
     elif spec_url:
        loader = URLLoader(spec_url)
     else:
-        if git_type == 'github':
+        if git_type == static.TYPE_GITHUB:
             glogger.debug("Building GithubLoader....")
             loader = GithubLoader(user, repo, subdir, sha, prov)
         else:

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,7 +3,7 @@ import grlc.gquery as gquery
 import grlc.pagination as pageUtils
 import grlc.swagger as swagger
 from grlc.prov import grlcPROV
-from grlc.fileLoaders import GithubLoader, LocalLoader, URLLoader
+from grlc.fileLoaders import GithubLoader, LocalLoader, URLLoader, GitlabLoader
 from grlc.queryTypes import qType
 from grlc import __version__ as grlc_version
 
@@ -19,14 +19,19 @@ import grlc.glogging as glogging
 
 glogger = glogging.getGrlcLogger(__name__)
 
-def getLoader(user, repo, subdir=None, spec_url=None, sha=None, prov=None):
+def getLoader(user, repo, subdir=None, spec_url=None, sha=None, prov=None, git_type=None, branch='main'):
     """Build a fileLoader (LocalLoader, GithubLoader, URLLoader) for the given parameters."""
     if user is None and repo is None and not spec_url:
         loader = LocalLoader()
     elif spec_url:
        loader = URLLoader(spec_url)
     else:
-        loader = GithubLoader(user, repo, subdir, sha, prov)
+        if git_type == 'github':
+            glogger.debug("Building GithubLoader....")
+            loader = GithubLoader(user, repo, subdir, sha, prov)
+        else:
+            glogger.debug("Building GitlabLoader....")
+            loader = GitlabLoader(user, repo, subdir, sha, prov, branch)
     return loader
 
 
@@ -40,7 +45,7 @@ def build_spec(user, repo, subdir=None, sha=None, prov=None, extraMetadata=[]):
     return items
 
 
-def build_swagger_spec(user, repo, subdir, spec_url, sha, serverName):
+def build_swagger_spec(user, repo, subdir, spec_url, sha, serverName, git_type, branch='main'):
     """Build grlc specification for the given github user / repo in swagger format."""
     if user and repo:
         # Init provenance recording
@@ -52,7 +57,7 @@ def build_swagger_spec(user, repo, subdir, spec_url, sha, serverName):
     swag['host'] = serverName
 
     try:
-        loader = getLoader(user, repo, subdir, spec_url, sha, prov_g)
+        loader = getLoader(user, repo, subdir, spec_url, sha, prov_g, git_type, branch)
     except Exception as e:
         # If repo does not exits
         swag['info'] = {
@@ -70,7 +75,7 @@ def build_swagger_spec(user, repo, subdir, spec_url, sha, serverName):
     swag['basePath'] = basePath
 
     # TODO: can we pass loader to build_spec ? --> Ideally yes!
-    spec, warnings = swagger.build_spec(user, repo, subdir, spec_url, sha, prov_g)
+    spec, warnings = swagger.build_spec(user, repo, subdir, spec_url, sha, prov_g, [], git_type, branch)
     # Use items to build API paths
     for item in spec:
         swag['paths'][item['call_name']] = swagger.get_path_for_item(item)
@@ -90,9 +95,9 @@ def build_swagger_spec(user, repo, subdir, spec_url, sha, serverName):
 
 def dispatch_query(user, repo, query_name, subdir=None, spec_url=None, sha=None, 
         content=None, requestArgs={}, acceptHeader='application/json',
-        requestUrl='http://', formData={}):
+        requestUrl='http://', formData={}, git_type=None, branch='main'):
     """Executes the specified SPARQL or TPF query."""
-    loader = getLoader(user, repo, subdir, spec_url, sha=sha, prov=None)
+    loader = getLoader(user, repo, subdir, spec_url, sha=sha, prov=None, git_type=git_type, branch=branch)
     query, q_type = loader.getTextForName(query_name)
 
     # Call name implemented with SPARQL query

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -31,6 +31,11 @@ class MockGithubRepo:
             return None
 
 
+class MockGitlabRepo:
+    pass
+
+
+
 def mock_requestsUrl(url, headers={}, params={}):
     url = url.replace('http://example.org/', 'tests/repo/')
     f = open(url, 'r')

--- a/tests/test_grlc.py
+++ b/tests/test_grlc.py
@@ -23,7 +23,7 @@ class TestGrlcLib(unittest.TestCase):
 
         user = 'testuser'
         repo = 'testrepo'
-        spec, warning = swagger.build_spec(user=user, repo=repo)
+        spec, warning = swagger.build_spec(user=user, repo=repo, git_type="github")
 
         self.assertEqual(len(spec), len(filesInRepo))
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -3,10 +3,10 @@ import six
 from mock import patch
 from os import path
 
-from grlc.fileLoaders import LocalLoader, GithubLoader, URLLoader
+from grlc.fileLoaders import LocalLoader, GithubLoader, GitlabLoader, URLLoader
 from grlc.queryTypes import qType
 
-from tests.mock_data import MockGithubRepo, mock_requestsUrl
+from tests.mock_data import MockGithubRepo, MockGitlabRepo, mock_requestsUrl
 
 
 class TestGithubLoader(unittest.TestCase):
@@ -16,6 +16,72 @@ class TestGithubLoader(unittest.TestCase):
         self.user = 'fakeuser'
         self.repo = 'fakerepo'
         self.loader = GithubLoader(self.user, self.repo, subdir=None, sha=None, prov=None)
+
+    def test_fetchFiles(self):
+        files = self.loader.fetchFiles()
+
+        # Should return a list of file items
+        self.assertIsInstance(files, list, "Should return a list of file items")
+
+        # Should have N files (where N=9)
+        self.assertEqual(len(files), 9, "Should return correct number of files")
+
+        # File items should have a download_url
+        for fItem in files:
+            self.assertIn('download_url', fItem, "File items should have a download_url")
+
+    def test_getRawRepoUri(self):
+        repoUri = self.loader.getRawRepoUri()
+
+        # Should be a string
+        self.assertIsInstance(repoUri, six.string_types, "Should be a string")
+
+        # For URI shoud contain user / repo
+        self.assertIn(self.user, repoUri, "Should contain user")
+        self.assertIn(self.repo, repoUri, "Should contain repo")
+
+    def test_getTextFor(self):
+        files = self.loader.fetchFiles()
+
+        # the contents of each file
+        for fItem in files:
+            text = self.loader.getTextFor(fItem)
+
+            # Should be some text
+            self.assertIsInstance(text, six.string_types, "Should be some text")
+
+            # Should be non-empty for existing items
+            self.assertGreater(len(text), 0, "Should be non-empty")
+
+        # Should raise exception for invalid file items
+        with self.assertRaises(Exception, msg="Should raise exception for invalid file items"):
+            text = self.loader.getTextFor({})
+
+    def test_getTextForName(self):
+        testableNames = [
+            ('test-rq', qType['SPARQL']),
+            ('test-sparql', qType['SPARQL']),
+            ('test-tpf', qType['TPF'])
+        ]
+        for name, expectedType in testableNames:
+            text, actualType = self.loader.getTextForName(name)
+            self.assertEqual(expectedType, actualType, "Query type should match %s != %s" % (expectedType, actualType))
+
+    def test_getEndpointText(self):
+        endpoint = self.loader.getEndpointText()
+
+        # Should be some text
+        self.assertIsInstance(endpoint, six.string_types, "Should be some text")
+
+
+class TestGitlabLoader(unittest.TestCase):
+    @classmethod
+    # TODO: patch gitlab object?
+    # @patch('???', return_value=MockGitlabRepo())
+    def setUpClass(self, mocked_repo):
+        self.user = 'fakeuser'
+        self.repo = 'fakerepo'
+        self.loader = GitlabLoader(self.user, self.repo, subdir=None, sha=None, prov=None)
 
     def test_fetchFiles(self):
         files = self.loader.fetchFiles()

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -19,7 +19,7 @@ class TestSwagger(unittest.TestCase):
 
         user = 'testuser'
         repo = 'testrepo'
-        spec, warnings = build_spec(user, repo)
+        spec, warnings = build_spec(user, repo, git_type="github")
 
         self.assertEqual(len(spec), len(filesInRepo))
 


### PR DESCRIPTION
Continuing here from #387

A few issues that remain:
 - Method [dispatch_query](https://github.com/CLARIAH/grlc/compare/master...Orange-OpenSource:grlc:master#diff-843cf1395093d42946cea4b5b53f687c535a7bd94d358b2c59e8f3e5a18d830aR201-R229) seems to be significantly different. It looks like it just posts request directly to the endpoint, without rewriting the query (which, we want to do), so I am sticking to the original implementation (unless I am missing something somewhere)

 - Variable `git_type` is used to differentiate between GitHub and GitLab loaders. It is assigned `"github"` and `"gitlab"` -- it should probably be replaced for a constant.

 - Tests for gitlab are missing