### PR TITLE
Adds endpoint-method decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ grlc can also use a subdirectory inside your Github repo. This can be done by in
 
 grlc can build an API from any GitLab repository, specified by the GitLab user name of the owner (`<user>`) and repository name (`<repo>`).
 
-For example, assuming your queries are stored on a GitLAb repo: `https://gitlab.com/c-martinez/grlc-queries`, point your browser to the following location
+For example, assuming your queries are stored on a GitLab repo: `https://gitlab.com/c-martinez/grlc-queries`, point your browser to the following location
 `http://grlc.io/api-gitlab/c-martinez/grlc-queries/`
 
 grlc can make use of git's version control mechanism to generate an API based on a specific version of queries in the repository. This can be done by including the name of a branch in the URL path (`http://grlc-server/api-gitlab/<user>/<repo>/branch/<branch>`), for example: `http://grlc.io/api-gitlab/c-martinez/grlc-queries/branch/master`
@@ -263,6 +263,16 @@ Syntax:
 ```
 
 Example [query](https://github.com/CLARIAH/grlc-queries/blob/master/transform.rq) and the equivalent [API operation](http://grlc.io/api-git/CLARIAH/grlc-queries/#/default/get_transform).
+
+### `endpoint-method`
+Allows the query to be sent from the grlc server to the SPARQL endpoint using either `GET` or `POST` http method. (Default: `POST`)
+
+Syntax:
+```
+#+ endpoint-method: GET
+```
+
+Example [query](https://github.com/CLARIAH/grlc-queries/blob/master/endpoint-method.rq) and the equivalent [API operation](http://grlc.io/api-git/CLARIAH/grlc-queries/#/default/get_endpoint_method).
 
 ### Example APIs
 

--- a/tests/repo/test-endpoint-get.rq
+++ b/tests/repo/test-endpoint-get.rq
@@ -1,0 +1,12 @@
+#+ summary: Sample query for testing SPARQL endpoint method
+#+ endpoint: "http://test-endpoint/transform/sparql/"
+#+ transform: {
+#+     "key": "?p",
+#+     "value": "?o",
+#+     "$anchor": "key"
+#+   }
+#+ endpoint-method: GET
+
+select ?p ?o where {
+  ?_id_iri ?p ?o
+} LIMIT 5

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -29,8 +29,8 @@ class TestGithubLoader(unittest.TestCase):
         # Should return a list of file items
         self.assertIsInstance(files, list, "Should return a list of file items")
 
-        # Should have N files (where N=9)
-        self.assertEqual(len(files), 9, "Should return correct number of files")
+        # Should have N files (where N=10)
+        self.assertEqual(len(files), 10, "Should return correct number of files")
 
         # File items should have a download_url
         for fItem in files:
@@ -104,8 +104,8 @@ class TestGitlabLoader(unittest.TestCase):
         # Should return a list of file items
         self.assertIsInstance(files, list, "Should return a list of file items")
 
-        # Should have N files (where N=9)
-        self.assertEqual(len(files), 9, "Should return correct number of files")
+        # Should have N files (where N=10)
+        self.assertEqual(len(files), 10, "Should return correct number of files")
 
         # File items should have a download_url
         for fItem in files:
@@ -174,8 +174,8 @@ class TestLocalLoader(unittest.TestCase):
         # Should return a list of file items
         self.assertIsInstance(files, list, "Should return a list of file items")
 
-        # Should have N files (where N=9)
-        self.assertEqual(len(files), 9, "Should return correct number of files")
+        # Should have N files (where N=10)
+        self.assertEqual(len(files), 10, "Should return correct number of files")
 
         # File items should have a download_url
         for fItem in files:


### PR DESCRIPTION
As suggested by @tkuhn in https://github.com/CLARIAH/grlc/commit/b09824ab3673cb34b2400b78d275f512d0d1a43c. 

Adds a new decorator: `endpoint-method` which can be set to `POST` or `GET` (default `POST`). This allows to control the HTTP method used to communicate between the grlc server and the SPARQL endpoint. According to https://www.w3.org/TR/sparql11-protocol/, both GET and POST are supported.

