### PR TITLE
Docopt dead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docopt==0.6.2
+docopt-ng==0.9.0
 Flask==3.0.0
 Flask-Cors==4.0.0
 pyaml==23.9.5


### PR DESCRIPTION
I recently found out that `docopt` is no longer maintained (last update was 2014, see https://github.com/docopt/docopt/issues/519). Fortunately a fork project seems to be actively maintained: https://github.com/jazzband/docopt-ng

This PR migrates from `docopt` to `docopt-ng`.