### PR TITLE
Transformer json check

### DIFF
--- a/src/gquery.py
+++ b/src/gquery.py
@@ -265,6 +265,7 @@ def get_yaml_decorators(rq):
 
     yaml_string = ""
     query_string = ""
+    query_metadata = None
     if isinstance(rq, dict):  # json query (sparql transformer)
         if "grlc" in rq:
             yaml_string = rq["grlc"]

--- a/src/utils.py
+++ b/src/utils.py
@@ -446,3 +446,10 @@ def dispatchTPFQuery(raw_tpf_query, loader, acceptHeader, content):
     headers["Content-Type"] = response.headers["Content-Type"]
     headers["Server"] = "grlc/" + grlc_version
     return resp, 200, headers
+
+
+def SPARQLTransformer_validJSON(json_file):
+    """Validate json file (loaded into Python as a dict) is a valid query for
+    SPARQLTransformer (see https://github.com/D2KLab/py-sparql-transformer/issues/13).
+    """
+    return ("@graph" in json_file) or ("proto" in json_file)

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -128,7 +128,12 @@ filesInRepo = [
         "name": "fakeFile1.rq",
         "download_url": "https://example.org/path/to/fakeFile.rq",
         "decoded_content": "CONTENT ?".encode(),  # Because Github ContentFile object contains bytes.
-    }
+    },
+    {
+        "name": "fakeJSONFile1.json",
+        "download_url": "https://example.org/path/to/fakeJSONFile1.json",
+        "decoded_content": '{ "x": "y" }'.encode(),  # Because Github ContentFile object contains bytes.
+    },
 ]
 
 mockLoader = LocalLoader(base_url)

--- a/tests/test_grlc.py
+++ b/tests/test_grlc.py
@@ -37,7 +37,8 @@ class TestGrlcLib(unittest.TestCase):
         repo = "testrepo"
         spec, warning = swagger.build_spec(user=user, repo=repo, git_type="github")
 
-        self.assertEqual(len(spec), len(filesInRepo))
+        # Repo contains one JSON file which is not a query, and should be ignored
+        self.assertEqual(len(spec), len(filesInRepo) - 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -29,7 +29,8 @@ class TestSwagger(unittest.TestCase):
         repo = "testrepo"
         spec, warnings = build_spec(user, repo, git_type="github")
 
-        self.assertEqual(len(spec), len(filesInRepo))
+        # Repo contains one JSON file which is not a query, and should be ignored
+        self.assertEqual(len(spec), len(filesInRepo) - 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a check to make sure JSON files in a repository are valid for SPARQLTransformer, and can be processed as queries to generate API endpoints. If a JSON file is not a valid query, it will  be ignored.

Addresses #481 