### PR TITLE
Add gitlab.com as default in config.ini

### DIFF
--- a/config.default.ini
+++ b/config.default.ini
@@ -23,4 +23,4 @@ password = none
 debug = True
 
 [api_gitlab]
-gitlab_url=https://gitlab
+gitlab_url=https://gitlab.com


### PR DESCRIPTION
Makes https://gitlab.com be the default gitlab instance used in config.ini (in the config.default.ini file provided)

Fixes #486 