### PR TITLE
Update publish_pypi.yml

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -18,9 +18,5 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
         python setup.py sdist bdist_wheel
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1.4.2
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        # repository_url: https://test.pypi.org/legacy/
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 mock==5.2.0
-pytest==8.3.4
+pytest==8.3.5
 flake8==7.2.0
 six==1.17.0


### PR DESCRIPTION
Updating action according to https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file

Trusted publishing has been enabled in PyPI.